### PR TITLE
Added editable filename UI to PythonActor, moved loading to main thread.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ install:
   - cd -
 
   # libsphactor
-  - git clone --depth=1 --branch=master https://github.com/sphaero/libsphactor
+  - git clone --depth=1 --branch=master https://github.com/hku-ect/libsphactor
   - cd libsphactor
   - ./autogen.sh
   - ./configure

--- a/Actors/PythonActor.h
+++ b/Actors/PythonActor.h
@@ -15,17 +15,30 @@ public:
                                                           { {"OSC", ActorSlotOSC} },       // Output slots
                                                             uuid )                        // uuid pass-through
     {
-
+        if ( filename == nullptr ) {
+            filename = new char[32];
+            sprintf(filename, "tester");
+            this->UpdatePythonFile();
+        }
+    }
+    
+    virtual ~PythonActor() {
+        delete[] filename;
     }
 
     int UpdatePythonFile();
 
     void ActorInit( const sphactor_actor_t *actor );
     zmsg_t *ActorMessage( sphactor_event_t *ev );
-    //zmsg_t *ActorCallback( );
-    //void ActorStop(const sphactor_node_t *node);
+    
+    // Serialization overrides
+    void SerializeActorData( zconfig_t *section );
+    void DeserializeActorData( ImVector<char*> *args, ImVector<char*>::iterator it );
+    
+    // UI overrides
+    void Render(float deltaTime);
 
-    std::string filename = "tester";
+    char * filename = nullptr;
     PyObject *pClassInstance;
 };
 

--- a/main.cpp
+++ b/main.cpp
@@ -127,7 +127,7 @@ int main(int argc, char** argv)
         flags |= O_NONBLOCK;
         fcntl(out_pipe[0], F_SETFL, flags);
         
-        dup2(out_pipe[1], STDOUT_FILENO);   /* redirect stdout to the pipe */
+        dup2(out_pipe[1], STDOUT_FILENO);
         close(out_pipe[1]);
     }
     


### PR DESCRIPTION
PythonActors now load "tester" by default, and save their modulename through zconfig. Deserialization leads to a double init (first from constructor, then from zconfig), but this doesn't appear to cause any issues.