### PR TITLE
Directly output stdout (unbuffered)

### DIFF
--- a/Actors/PythonActor.cpp
+++ b/Actors/PythonActor.cpp
@@ -7,6 +7,7 @@
 void
 python_init()
 {
+    Py_UnbufferedStdioFlag = 1;
     //  add internal wrapper to available modules
     PyImport_AppendInittab("sph", PyInit_PyZmsg);
     Py_Initialize();


### PR DESCRIPTION
This way stdout from python is directly visible in the console.

Unbuffered stdio flag set to 1, seems to work