### PR TITLE
OSC Input node. Renamed Client to OSC Output. Barebones NatNet actor.

### DIFF
--- a/ActorContainer.h
+++ b/ActorContainer.h
@@ -215,7 +215,7 @@ struct ActorContainer {
         zosc_t * customData = sphactor_report_custom(report);
         if ( customData ) {
             const char* address = zosc_address(customData);
-            ImGui::Text(address);
+            ImGui::Text("%s", address);
 
             char type = '0';
             const void *data = zosc_first(customData, &type);

--- a/ActorContainer.h
+++ b/ActorContainer.h
@@ -239,7 +239,7 @@ struct ActorContainer {
                         case 's': {
                             char* value;
                             zosc_pop_string(customData, &value);
-                            ImGui::Text(value);
+                            ImGui::Text("%s", value);
                         } break;
                         case 'c': {
                             char value;
@@ -315,7 +315,7 @@ struct ActorContainer {
         ReadInt( &step, zstep);
 
         ImGui::SetNextItemWidth(100);
-        if ( ImGui::InputInt( name, &value, step) ) {
+        if ( ImGui::InputInt( name, &value, step, 100,ImGuiInputTextFlags_EnterReturnsTrue ) ) {
             if ( min != max ) {
                 if ( value < min ) value = min;
                 if ( value > max ) value = max;
@@ -458,7 +458,7 @@ struct ActorContainer {
                     while ( data && it != args->end() ) {
                         zconfig_t *value = zconfig_locate(data,"value");
                         char* valueStr = *it;
-                        zconfig_set_value(value, valueStr);
+                        zconfig_set_value(value, "%s", valueStr);
 
                         HandleAPICalls(data);
                         data = zconfig_next(data);

--- a/ActorContainer.h
+++ b/ActorContainer.h
@@ -376,7 +376,7 @@ struct ActorContainer {
         strcpy(buf, zvalueStr);
 
         ImGui::SetNextItemWidth(200);
-        if ( ImGui::InputText(name, buf, max ) ) {
+        if ( ImGui::InputText(name, buf, max, ImGuiInputTextFlags_EnterReturnsTrue ) ) {
             zconfig_set_value(zvalue, "%s", buf);
             SendAPI<char*>(zapic, zapiv, zvalue, &buf);
         }
@@ -456,6 +456,10 @@ struct ActorContainer {
                 if ( root ) {
                     zconfig_t *data = zconfig_locate(root, "data");
                     while ( data && it != args->end() ) {
+                        zconfig_t *value = zconfig_locate(data,"value");
+                        char* valueStr = *it;
+                        zconfig_set_value(value, valueStr);
+
                         HandleAPICalls(data);
                         data = zconfig_next(data);
                         it++;

--- a/ActorContainer.h
+++ b/ActorContainer.h
@@ -95,21 +95,63 @@ struct ActorContainer {
 
         zconfig_t *data = zconfig_locate(root, "data");
         while( data != NULL ) {
-            zconfig_t *zapic = zconfig_locate(data, "api_call");
-            if ( zapic ) {
-                zconfig_t *zapiv = zconfig_locate(data, "api_value");
-                zconfig_t *value = zconfig_locate(data, "value");
-                if (zapiv)
-                {
-                    std::string pic = "s";
-                    pic += zconfig_value(zapiv);
-                    zsock_send( sphactor_socket(this->actor), pic.c_str(), zconfig_value(zapic), value);
-                }
-                else
-                    zsock_send( sphactor_socket(this->actor), "si", zconfig_value(zapic), value);
-            }
+            HandleAPICalls(data);
             data = zconfig_next(data);
         }
+    }
+
+    void HandleAPICalls(zconfig_t * data) {
+        zconfig_t *zapic = zconfig_locate(data, "api_call");
+        if ( zapic ) {
+            zconfig_t *zapiv = zconfig_locate(data, "api_value");
+            zconfig_t *zvalue = zconfig_locate(data, "value");
+
+            if (zapiv)
+            {
+                char * zapivStr = zconfig_value(zapiv);
+                char type = zapivStr[0];
+                switch( type ) {
+                    case 'i':
+                        int ival;
+                        ReadInt(&ival, zvalue);
+                        SendAPI<int>(zapic, zapiv, zvalue, &ival);
+                    break;
+                    case 'f':
+                        float fval;
+                        ReadFloat(&fval, zvalue);
+                        SendAPI<float>(zapic, zapiv, zvalue, &fval);
+                    break;
+                    case 's':
+                        char* buf = new char[MAX_STR_DEFAULT];
+                        const char* zvalueStr = zconfig_value(zvalue);
+                        strcpy(buf, zvalueStr);
+                        SendAPI<char*>(zapic, zapiv, zvalue, &buf);
+                        zstr_free(&buf);
+                    break;
+                }
+            }
+            else {
+                //assume int
+                int ival;
+                ReadInt(&ival, zvalue);
+                zsock_send( sphactor_socket(this->actor), "si", zconfig_value(zapic), ival);
+            }
+        }
+    }
+
+    template<typename T>
+    void SendAPI(zconfig_t *zapic, zconfig_t *zapiv, zconfig_t *zvalue, T * value) {
+        if ( !zapic ) return;
+
+        if (zapiv)
+        {
+            std::string pic = "s";
+            pic += zconfig_value(zapiv);
+            //zsys_info("Sending: %s", pic.c_str());
+            zsock_send( sphactor_socket(this->actor), pic.c_str(), zconfig_value(zapic), *value);
+        }
+        else
+            zsock_send( sphactor_socket(this->actor), "si", zconfig_value(zapic), *value);
     }
 
     void Parse(zconfig_t * config, const char* node, std::vector<ImNodes::Ez::SlotInfo> *list ) {
@@ -262,7 +304,6 @@ struct ActorContainer {
         zconfig_t * zapic = zconfig_locate(data, "api_call");
         zconfig_t * zapiv = zconfig_locate(data, "api_value");
         assert(zvalue);
-        assert(zapic);
 
         zconfig_t * zmin = zconfig_locate(data, "min");
         zconfig_t * zmax = zconfig_locate(data, "max");
@@ -281,14 +322,7 @@ struct ActorContainer {
             }
 
             zconfig_set_value(zvalue, "%i", value);
-            if (zapiv)
-            {
-                std::string pic = "s";
-                pic += zconfig_value(zapiv);
-                zsock_send( sphactor_socket(this->actor), pic.c_str(), zconfig_value(zapic), value);
-            }
-            else
-                zsock_send( sphactor_socket(this->actor), "si", zconfig_value(zapic), value);
+            SendAPI<int>(zapic, zapiv, zvalue, &value);
         }
     }
 
@@ -297,6 +331,8 @@ struct ActorContainer {
         float min = 0, max = 0, step = 0;
 
         zconfig_t * zvalue = zconfig_locate(data, "value");
+        zconfig_t * zapic = zconfig_locate(data, "api_call");
+        zconfig_t * zapiv = zconfig_locate(data, "api_value");
         assert(zvalue);
 
         zconfig_t * zmin = zconfig_locate(data, "min");
@@ -312,11 +348,13 @@ struct ActorContainer {
         if ( min != max ) {
             if ( ImGui::SliderFloat( name, &value, min, max) ) {
                 zconfig_set_value(zvalue, "%f", value);
+                SendAPI<float>(zapic, zapiv, zvalue, &value);
             }
         }
         else {
             if ( ImGui::InputFloat( name, &value, min, max) ) {
                 zconfig_set_value(zvalue, "%f", value);
+                SendAPI<float>(zapic, zapiv, zvalue, &value);
             }
         }
     }
@@ -325,6 +363,8 @@ struct ActorContainer {
         int max = MAX_STR_DEFAULT;
 
         zconfig_t * zvalue = zconfig_locate(data, "value");
+        zconfig_t * zapic = zconfig_locate(data, "api_call");
+        zconfig_t * zapiv = zconfig_locate(data, "api_value");
         assert(zvalue);
 
         zconfig_t * zmax = zconfig_locate(data, "max");
@@ -338,6 +378,7 @@ struct ActorContainer {
         ImGui::SetNextItemWidth(200);
         if ( ImGui::InputText(name, buf, max ) ) {
             zconfig_set_value(zvalue, "%s", buf);
+            SendAPI<char*>(zapic, zapiv, zvalue, &buf);
         }
 
         free(buf);
@@ -415,22 +456,7 @@ struct ActorContainer {
                 if ( root ) {
                     zconfig_t *data = zconfig_locate(root, "data");
                     while ( data && it != args->end() ) {
-                        zconfig_t *value = zconfig_locate(data,"value");
-                        char* valueStr = *it;
-                        zconfig_set_value(value, valueStr);
-
-                        zconfig_t *zapic = zconfig_locate(data, "api_call");
-                        if ( zapic ) {
-                            zconfig_t *zapiv = zconfig_locate(data, "api_value");
-                            if (zapiv)
-                            {
-                                std::string pic = "s";
-                                pic += zconfig_value(zapiv);
-                                zsock_send( sphactor_socket(this->actor), pic.c_str(), zconfig_value(zapic), atoi(valueStr));
-                            }
-                            else
-                                zsock_send( sphactor_socket(this->actor), "si", zconfig_value(zapic), atoi(valueStr));
-                        }
+                        HandleAPICalls(data);
                         data = zconfig_next(data);
                         it++;
                     }

--- a/Actors/ClientActor.cpp
+++ b/Actors/ClientActor.cpp
@@ -45,8 +45,6 @@ zmsg_t* Client::handleMsg( sphactor_event_t * ev ) {
         if ( ev->msg == NULL ) return NULL;
         if ( this->dgrams == NULL ) return ev->msg;
 
-
-
         byte *msgBuffer;
         zframe_t* frame;
 
@@ -61,7 +59,7 @@ zmsg_t* Client::handleMsg( sphactor_event_t * ev ) {
                 //zosc_t * oscMsg = zosc_frommem( (char*)msgBuffer, len);
                 int rc = zsock_send( dgrams, "b", msgBuffer, len);//zosc_data(oscMsg), zosc_size(oscMsg));
                 if ( rc != 0 ) {
-                    zsys_info("Error sending zosc message to: %s", this->host.c_str());
+                    zsys_info("Error sending zosc message to: %s, %i", this->host.c_str(), rc);
                 }
             }
         } while (frame != NULL );

--- a/Actors/ClientActor.cpp
+++ b/Actors/ClientActor.cpp
@@ -1,0 +1,14 @@
+#include "ClientActor.h"
+
+zmsg_t* Client::handleMsg( sphactor_event_t * ev ) {
+
+    if ( streq(ev->type, "INIT") ) {
+        //TODO: init capabilities
+
+        //TODO: Create default dgram socket?
+    }
+    else if ( streq(ev->type, "INIT") ) {
+        //TODO: send msg over our dgram socket, if it exists
+    }
+    return NULL;
+}

--- a/Actors/ClientActor.cpp
+++ b/Actors/ClientActor.cpp
@@ -1,14 +1,95 @@
 #include "ClientActor.h"
+#include <string>
+
+const char * clientCapabilities =
+                                "capabilities\n"
+                                "    data\n"
+                                "        name = \"ip\"\n"
+                                "        type = \"string\"\n"
+                                "        value = \"192.168.0.1\"\n"
+                                "        api_call = \"SET HOST\"\n"
+                                "        api_value = \"s\"\n"           // optional picture format used in zsock_send
+                                "    data\n"
+                                "        name = \"port\"\n"
+                                "        type = \"int\"\n"
+                                "        value = \"6200\"\n"
+                                "        min = \"1\"\n"
+                                "        max = \"10000\"\n"
+                                "        api_call = \"SET PORT\"\n"
+                                "        api_value = \"i\"\n"           // optional picture format used in zsock_send
+                                "inputs\n"
+                                "    input\n"
+                                "        type = \"OSC\"\n";
 
 zmsg_t* Client::handleMsg( sphactor_event_t * ev ) {
 
     if ( streq(ev->type, "INIT") ) {
-        //TODO: init capabilities
+        //init capabilities
+        sphactor_actor_set_capability((sphactor_actor_t*)ev->actor, zconfig_str_load(clientCapabilities));
+    }
+    /*
+     * Application will hang if done here when closing application entirely...
+     * Even if you have destroyed client actors in between... very odd...
+     * */
+    else if ( streq(ev->type, "DESTROY") ) {
+        zsys_info("Handling Destroy");
+        //TODO: Fix zsys_shutdown crash when destroying dgrams along the way...
+        if ( this->dgrams != NULL ) {
+            //zsock_destroy(&this->dgrams);
+            this->dgrams = NULL;
+        }
 
-        //TODO: Create default dgram socket?
+        return ev->msg;
     }
-    else if ( streq(ev->type, "INIT") ) {
-        //TODO: send msg over our dgram socket, if it exists
+    else if ( streq(ev->type, "SOCK") ) {
+        //TODO: send input message out over this->dgrams
     }
-    return NULL;
+    else if ( streq(ev->type, "API")) {
+        //pop msg for command
+        char * cmd = zmsg_popstr(ev->msg);
+        if (cmd) {
+            if ( streq(cmd, "SET PORT") ) {
+                if ( this->dgrams != NULL ) {
+                    zsock_destroy(&this->dgrams);
+                }
+
+                char * port = zmsg_popstr(ev->msg);
+
+                this->port = port;
+                std::string url = ("udp://" + this->host + ":" + this->port);
+                this->dgrams = zsock_new_dgram(url.c_str());
+
+                zsys_info("SET PORT: %s", url.c_str());
+
+                zstr_free(&port);
+            }
+            else if ( streq(cmd, "SET HOST") ) {
+                if ( this->dgrams != NULL ) {
+                    zsock_destroy(&this->dgrams);
+                }
+
+                char * host_addr = zmsg_popstr(ev->msg);
+                this->host = host_addr;
+
+                std::string url = ("udp://" + this->host + ":" + this->port);
+                this->dgrams = zsock_new_dgram(url.c_str());
+
+                if ( this->dgrams == NULL ) {
+                    zsys_info("Could not create dgram: %s", url.c_str());
+                }
+
+                zsys_info("SET HOST: %s", host_addr);
+
+                zstr_free(&host_addr);
+            }
+
+            zstr_free(&cmd);
+        }
+
+        zmsg_destroy(&ev->msg);
+
+        return NULL;
+    }
+
+    return ev->msg;
 }

--- a/Actors/ClientActor.h
+++ b/Actors/ClientActor.h
@@ -2,13 +2,27 @@
 #define CLIENTACTOR_H
 
 #include "libsphactor.h"
+#include <string>
 
 struct Client {
+    zsock_t* dgrams = NULL;
+
+    std::string host = "";
+    std::string port = "";
 
     zmsg_t * handleMsg( sphactor_event_t * ev );
 
     Client() {
 
+    }
+
+    /* This is never called */
+    ~Client() {
+        if ( this->dgrams != NULL ) {
+            zsys_info("Destroying dgrams");
+            zsock_destroy(&this->dgrams);
+            this->dgrams = NULL;
+        }
     }
 };
 

--- a/Actors/ClientActor.h
+++ b/Actors/ClientActor.h
@@ -1,0 +1,15 @@
+#ifndef CLIENTACTOR_H
+#define CLIENTACTOR_H
+
+#include "libsphactor.h"
+
+struct Client {
+
+    zmsg_t * handleMsg( sphactor_event_t * ev );
+
+    Client() {
+
+    }
+};
+
+#endif // CLIENTACTOR_H

--- a/Actors/CountActor.cpp
+++ b/Actors/CountActor.cpp
@@ -16,7 +16,6 @@ Count::handleMsg( sphactor_event_t *ev ) {
     }
     else if ( streq(ev->type, "SOCK")) {
         this->msgCount++;
-        zsys_info("SOCK EVENT %i", this->msgCount);
         zosc_t * msg = zosc_create("/report", "ssscsishsf",
                                                 "Some Text", "12345678",
                                                 "Some Char", 'q',     //TODO: FIX

--- a/Actors/LogActor.cpp
+++ b/Actors/LogActor.cpp
@@ -10,27 +10,30 @@ zmsg_t * LogActor( sphactor_event_t *ev, void* args ) {
     }
     else
     if ( streq(ev->type, "SOCK")) {
-    if ( ev->msg == NULL ) return NULL;
+        if ( ev->msg == NULL ) return NULL;
 
-    byte *msgBuffer;
-    zframe_t* frame;
+        byte *msgBuffer;
+        zframe_t* frame;
 
-    do {
-    frame = zmsg_pop(ev->msg);
-        if ( frame ) {
-            //parse zosc_t msg
-            msgBuffer = zframe_data(frame);
-            size_t len = zframe_size(frame);
+        do {
+        frame = zmsg_pop(ev->msg);
+            if ( frame ) {
+                //parse zosc_t msg
+                msgBuffer = zframe_data(frame);
+                size_t len = zframe_size(frame);
 
-            const char* msg;
-            zosc_t * oscMsg = zosc_frommem( (char*)msgBuffer, len);
-            zosc_retr( oscMsg, "s", &msg );
+                //TODO: implement zosc message parsing
+                const char* msg;
+                zosc_t * oscMsg = zosc_frommem( (char*)msgBuffer, len);
+                zosc_retr( oscMsg, "s", &msg );
 
-            zsys_info("%s: %s", msgBuffer, msg);
-        }
-    } while (frame != NULL );
+                zsys_info("%s: %s", msgBuffer, msg);
+            }
+        } while (frame != NULL );
 
-    return NULL;
+        zmsg_destroy(&ev->msg);
+
+        return NULL;
     }
 
     return ev->msg;

--- a/Actors/NatNetActor.cpp
+++ b/Actors/NatNetActor.cpp
@@ -9,14 +9,14 @@ const char * natnetCapabilities =
                                 "        value = \"192.168.0.1\"\n"
                                 "        api_call = \"SET HOST\"\n"
                                 "        api_value = \"s\"\n"           // optional picture format used in zsock_send
-                                "    data\n"
-                                "        name = \"receive port\"\n"
-                                "        type = \"int\"\n"
-                                "        value = \"6200\"\n"
-                                "        min = \"1\"\n"
-                                "        max = \"10000\"\n"
-                                "        api_call = \"SET PORT\"\n"
-                                "        api_value = \"i\"\n"           // optional picture format used in zsock_send
+                                //"    data\n"
+                                //"        name = \"receive port\"\n"
+                                //"        type = \"int\"\n"
+                                //"        value = \"6200\"\n"
+                                //"        min = \"1\"\n"
+                                //"        max = \"10000\"\n"
+                                //"        api_call = \"SET PORT\"\n"
+                                //"        api_value = \"i\"\n"           // optional picture format used in zsock_send
                                 "outputs\n"
                                 "    output\n"
                                 "        type = \"OSC\"\n";
@@ -25,20 +25,22 @@ zmsg_t * NatNet::handleMsg( sphactor_event_t * ev ) {
     if ( streq(ev->type, "INIT") ) {
         //init capabilities
         sphactor_actor_set_capability((sphactor_actor_t*)ev->actor, zconfig_str_load(natnetCapabilities));
+        //TODO: Check receive port in NatNet specifications
+        this->dgrams = zsock_new_dgram("udp://*:1511");
     }
     /*
      * Application will hang if done here when closing application entirely...
      * Even if you have destroyed client actors in between... very odd...
      * */
     else if ( streq(ev->type, "DESTROY") ) {
-        zsys_info("Handling Destroy");
         //TODO: Fix zsys_shutdown crash when destroying dgrams along the way...
         if ( this->dgrams != NULL ) {
-            //zsock_destroy(&this->dgrams);
+            zsock_destroy(&this->dgrams);
             this->dgrams = NULL;
         }
         if ( this->dgramr != NULL ) {
-            //zsock_destroy(&this->dgramr);
+            //sphactor_actor_poller_remove(ev->actor, this->dgramr );
+            zsock_destroy(&this->dgramr);
             this->dgramr = NULL;
         }
 
@@ -51,28 +53,9 @@ zmsg_t * NatNet::handleMsg( sphactor_event_t * ev ) {
         //pop msg for command
         char * cmd = zmsg_popstr(ev->msg);
         if (cmd) {
-            if ( streq(cmd, "SET PORT") ) {
-                if ( this->dgramr != NULL ) {
-                    //TODO: poller remove in new form
-
-                    zsock_destroy(&this->dgramr);
-                }
-
-                char * port = zmsg_popstr(ev->msg);
-                std::string url = "udp://*.";
-                url += port;
-                this->dgramr = zsock_new_dgram(url.c_str());
-
-                //TODO: poller add in new format
-
-                zsys_info("SET PORT: %s", url.c_str());
-
-                zstr_free(&port);
-            }
-            else if ( streq(cmd, "SET HOST") ) {
+            if ( streq(cmd, "SET HOST") ) {
                 if ( this->dgrams != NULL ) {
                     //TODO: poller remove in new form
-
                     zsock_destroy(&this->dgrams);
                 }
 
@@ -85,17 +68,22 @@ zmsg_t * NatNet::handleMsg( sphactor_event_t * ev ) {
 
                 if ( this->dgrams != NULL ) {
                     //TODO: poller add in new format
+                    //sphactor_actor_poller_add(ev->actor, this->dgramr );
                 }
                 else {
                     zsys_info("Could not connect to host: %s", url.c_str());
                 }
 
                 zsys_info("SET HOST: %s", host_addr);
-
                 zstr_free(&host_addr);
             }
 
             zstr_free(&cmd);
+        }
+        else if ( streq(ev->type, "FDSOCK" ) )
+        {
+            //TODO: Read data from our socket...
+            //return zmsg_recv( self->sock );
         }
 
         zmsg_destroy(&ev->msg);

--- a/Actors/NatNetActor.cpp
+++ b/Actors/NatNetActor.cpp
@@ -9,16 +9,9 @@ const char * natnetCapabilities =
                                 "        value = \"192.168.0.1\"\n"
                                 "        api_call = \"SET HOST\"\n"
                                 "        api_value = \"s\"\n"           // optional picture format used in zsock_send
-                                //"    data\n"
-                                //"        name = \"receive port\"\n"
-                                //"        type = \"int\"\n"
-                                //"        value = \"6200\"\n"
-                                //"        min = \"1\"\n"
-                                //"        max = \"10000\"\n"
-                                //"        api_call = \"SET PORT\"\n"
-                                //"        api_value = \"i\"\n"           // optional picture format used in zsock_send
                                 "outputs\n"
                                 "    output\n"
+                                //TODO: Perhaps add NatNet output type so we can filter the data multiple times...
                                 "        type = \"OSC\"\n";
 
 zmsg_t * NatNet::handleMsg( sphactor_event_t * ev ) {
@@ -29,13 +22,13 @@ zmsg_t * NatNet::handleMsg( sphactor_event_t * ev ) {
         //TODO: Check receive port in NatNet specifications
         //receive socket on port 1511
         this->dgramr = zsock_new_dgram("udp://*:1511");
-        dgram_fd = zsock_fd(this->dgramr);
+        assert( this->dgramr );
+        int rc = sphactor_actor_poller_add((sphactor_actor_t*)ev->actor, this->dgramr );
+        assert(rc == 0);
 
         //send socket on any
         this->dgrams = zsock_new_dgram("udp://*:*");
-        assert( this->dgramr && this->dgrams );
-        int rc = sphactor_actor_poller_add((sphactor_actor_t*)ev->actor, this->dgramr );
-        assert(rc == 0);
+        assert( this->dgrams );
     }
     /*
      * Application will hang if done here when closing application entirely...

--- a/Actors/NatNetActor.cpp
+++ b/Actors/NatNetActor.cpp
@@ -1,0 +1,88 @@
+#include "NatNetActor.h"
+#include <string>
+
+const char * natnetCapabilities =
+                                "capabilities\n"
+                                "    data\n"
+                                "        name = \"motive ip\"\n"
+                                "        type = \"string\"\n"
+                                "        value = \"192.168.0.1\"\n"
+                                "        api_call = \"SET HOST\"\n"
+                                "        api_value = \"s\"\n"           // optional picture format used in zsock_send
+                                "    data\n"
+                                "        name = \"receive port\"\n"
+                                "        type = \"int\"\n"
+                                "        value = \"6200\"\n"
+                                "        min = \"1\"\n"
+                                "        max = \"10000\"\n"
+                                "        api_call = \"SET PORT\"\n"
+                                "        api_value = \"i\"\n"           // optional picture format used in zsock_send
+                                "outputs\n"
+                                "    output\n"
+                                "        type = \"OSC\"\n";
+
+zmsg_t * NatNet::handleMsg( sphactor_event_t * ev ) {
+    if ( streq(ev->type, "INIT") ) {
+        //init capabilities
+        sphactor_actor_set_capability((sphactor_actor_t*)ev->actor, zconfig_str_load(natnetCapabilities));
+    }
+    else if ( streq(ev->type, "SOCK") ) {
+        //TODO: what is this? redirected msg from dgram socket?
+    }
+    else if ( streq(ev->type, "API")) {
+        //pop msg for command
+        char * cmd = zmsg_popstr(ev->msg);
+        if (cmd) {
+            if ( streq(cmd, "SET PORT") ) {
+                if ( this->dgramr != NULL ) {
+                    //TODO: poller remove in new form
+
+                    zsock_destroy(&this->dgramr);
+                }
+
+                char * port = zmsg_popstr(ev->msg);
+                std::string url = "udp://*.";
+                url += port;
+                this->dgramr = zsock_new_dgram(url.c_str());
+
+                //TODO: poller add in new format
+
+                zsys_info("SET PORT: %s", url.c_str());
+
+                zstr_free(&port);
+            }
+            else if ( streq(cmd, "SET HOST") ) {
+                if ( this->dgrams != NULL ) {
+                    //TODO: poller remove in new form
+
+                    zsock_destroy(&this->dgrams);
+                }
+
+                char * host_addr = zmsg_popstr(ev->msg);
+
+                std::string url = host_addr;
+                url += ":1511";
+                this->dgrams = zsock_new_dgram(url.c_str());
+
+                if ( this->dgrams != NULL ) {
+                    //TODO: poller add in new format
+                }
+                else {
+                    zsys_info("Could not connect to host: %s", url.c_str());
+                }
+
+                zsys_info("SET HOST: %s", host_addr);
+
+                zstr_free(&host_addr);
+            }
+
+            zstr_free(&cmd);
+        }
+
+        zmsg_destroy(&ev->msg);
+
+        return NULL;
+    }
+
+    return ev->msg;
+}

--- a/Actors/NatNetActor.h
+++ b/Actors/NatNetActor.h
@@ -6,9 +6,8 @@
 
 struct NatNet {
     // receive / send datagrams
-    // TODO: implement ofxNatNet?
+    // TODO: implement NatNet?
     zsock_t* dgramr = NULL;
-    SOCKET dgram_fd;
     zsock_t* dgrams = NULL;
 
     std::string host = "";

--- a/Actors/NatNetActor.h
+++ b/Actors/NatNetActor.h
@@ -4,7 +4,8 @@
 #include "libsphactor.h"
 
 struct NatNet {
-    // receive datagram
+    // receive / send datagrams
+    // TODO: implement ofxNatNet?
     zsock_t* dgramr = NULL;
     zsock_t* dgrams = NULL;
 

--- a/Actors/NatNetActor.h
+++ b/Actors/NatNetActor.h
@@ -2,12 +2,16 @@
 #define NATNETACTOR_H
 
 #include "libsphactor.h"
+#include <string>
 
 struct NatNet {
     // receive / send datagrams
     // TODO: implement ofxNatNet?
     zsock_t* dgramr = NULL;
+    SOCKET dgram_fd;
     zsock_t* dgrams = NULL;
+
+    std::string host = "";
 
     zmsg_t * handleMsg( sphactor_event_t *ev );
 
@@ -16,4 +20,4 @@ struct NatNet {
     }
 };
 
-#endif // NATNETACTOR_H
+#endif

--- a/Actors/NatNetActor.h
+++ b/Actors/NatNetActor.h
@@ -1,0 +1,18 @@
+#ifndef NATNETACTOR_H
+#define NATNETACTOR_H
+
+#include "libsphactor.h"
+
+struct NatNet {
+    // receive datagram
+    zsock_t* dgramr = NULL;
+    zsock_t* dgrams = NULL;
+
+    zmsg_t * handleMsg( sphactor_event_t *ev );
+
+    NatNet() {
+
+    }
+};
+
+#endif // NATNETACTOR_H

--- a/Actors/OSCInputActor.cpp
+++ b/Actors/OSCInputActor.cpp
@@ -1,0 +1,96 @@
+//
+// Created by Aaron Oostdijk on 08/12/2020.
+//
+
+#include "OSCInputActor.h"
+
+const char * oscInputCapabilities =
+        "capabilities\n"
+        "    data\n"
+        "        name = \"port\"\n"
+        "        type = \"int\"\n"
+        "        value = \"6200\"\n"
+        "        min = \"1\"\n"
+        "        max = \"10000\"\n"
+        "        api_call = \"SET PORT\"\n"
+        "        api_value = \"i\"\n"           // optional picture format used in zsock_send
+        "outputs\n"
+        "    output\n"
+        "        type = \"OSC\"\n";
+
+zmsg_t * OSCInput::handleMsg( sphactor_event_t *ev )
+{
+    if ( streq(ev->type, "INIT")) {
+        sphactor_actor_set_capability((sphactor_actor_t*)ev->actor, zconfig_str_load(oscInputCapabilities));
+    }
+    else if ( streq( ev->type, "API")) {
+        char * cmd = zmsg_popstr(ev->msg);
+        if (cmd) {
+            if ( streq(cmd, "SET PORT") ) {
+                char * port = zmsg_popstr(ev->msg);
+                this->port = port;
+                if ( this->dgramr ) {
+                    sphactor_actor_poller_remove((sphactor_actor_t*)ev->actor, this->dgramr);
+                    zsock_destroy(&this->dgramr);
+                }
+
+                std::string url = "udp://*:" + this->port;
+                this->dgramr = zsock_new_dgram(url.c_str());
+                if ( this->dgramr ) {
+                    sphactor_actor_poller_add((sphactor_actor_t *) ev->actor, this->dgramr);
+                    zsys_info("Listening on url: %s", url.c_str());
+                }
+                else {
+                    zsys_info("Error creating listener for url: %s", url.c_str());
+                }
+
+                zsys_info("SET PORT: %s", url.c_str());
+                zstr_free(&port);
+            }
+
+            zstr_free(&cmd);
+        }
+
+        zmsg_destroy(&ev->msg);
+
+        return NULL;
+    }
+    else if ( streq( ev->type, "FDSOCK")) {
+        zsys_info("GOT FDSOCK");
+
+        //TODO: Read data from our socket...
+        assert(ev->msg);
+        zframe_t *frame = zmsg_pop(ev->msg);
+        if (zframe_size(frame) == sizeof( void *) )
+        {
+            void *p = *(void **)zframe_data(frame);
+            zsock_t* sock = (zsock_t*) zsock_resolve( p );
+            if ( sock )
+            {
+                zmsg_t * zmsg = zmsg_recv(sock);
+                assert(zmsg);
+
+                //TODO: is this always the case?
+                char* source = zmsg_popstr(zmsg);
+                zstr_free(&source);
+
+                zframe_t * oscFrame = zmsg_pop(zmsg);
+                assert(oscFrame);
+
+                //repackage and return as new message
+                zmsg_t* oscMsg = zmsg_new();
+                zmsg_add(oscMsg, oscFrame);
+                return oscMsg;
+            }
+        }
+        else
+            zsys_error("args is not a zsock instance");
+
+        zmsg_destroy(&ev->msg);
+        zframe_destroy(&frame);
+
+        return NULL;
+    }
+
+    return ev->msg;
+}

--- a/Actors/OSCInputActor.h
+++ b/Actors/OSCInputActor.h
@@ -1,0 +1,17 @@
+//
+// Created by Aaron Oostdijk on 08/12/2020.
+//
+
+#ifndef GAZEBOSC_OSCINPUTACTOR_H
+#define GAZEBOSC_OSCINPUTACTOR_H
+
+#include "libsphactor.h"
+#include <string>
+
+struct OSCInput {
+    std::string port = "6200";
+    zsock_t* dgramr = NULL;
+    zmsg_t * handleMsg( sphactor_event_t *ev );
+};
+
+#endif //GAZEBOSC_OSCINPUTACTOR_H

--- a/Actors/OSCInputActor.h
+++ b/Actors/OSCInputActor.h
@@ -1,7 +1,3 @@
-//
-// Created by Aaron Oostdijk on 08/12/2020.
-//
-
 #ifndef GAZEBOSC_OSCINPUTACTOR_H
 #define GAZEBOSC_OSCINPUTACTOR_H
 

--- a/Actors/PulseActor.h
+++ b/Actors/PulseActor.h
@@ -7,7 +7,7 @@ struct Pulse {
     zmsg_t * handleMsg( sphactor_event_t *ev );
 
     Pulse() {
-        this->rate = 16; //60 fps default
+
     }
 };
 

--- a/actors.h
+++ b/actors.h
@@ -1,11 +1,11 @@
 #ifndef ACTORS_H
 #define ACTORS_H
 
+#include "Actors/ClientActor.h"
 #include "Actors/CountActor.h"
+#include "Actors/NatNetActor.h"
 #include "Actors/PulseActor.h"
 
-zmsg_t * CountActor( sphactor_event_t *ev, void* args );
 zmsg_t * LogActor( sphactor_event_t *ev, void* args  );
-zmsg_t * PulseActor( sphactor_event_t *ev, void* args );
 
 #endif

--- a/actors.h
+++ b/actors.h
@@ -4,6 +4,7 @@
 #include "Actors/ClientActor.h"
 #include "Actors/CountActor.h"
 #include "Actors/NatNetActor.h"
+#include "Actors/OSCInputActor.h"
 #include "Actors/PulseActor.h"
 
 zmsg_t * LogActor( sphactor_event_t *ev, void* args  );

--- a/stage.cpp
+++ b/stage.cpp
@@ -66,7 +66,7 @@ void UpdateRegisteredActorsCache() {
 
 void RegisterActors() {
     //TODO: Rename this actor...
-    sphactor_register<Client>( "Client" );
+    sphactor_register<Client>( "OSC Out" );
     sphactor_register<Count>( "Count" );
     sphactor_register( "Log", &LogActor, NULL, NULL );
     sphactor_register<NatNet>( "NatNet" );

--- a/stage.cpp
+++ b/stage.cpp
@@ -66,10 +66,11 @@ void UpdateRegisteredActorsCache() {
 
 void RegisterActors() {
     //TODO: Rename this actor...
-    sphactor_register<Client>( "OSC Out" );
+    sphactor_register<Client>( "OSC Output" );
     sphactor_register<Count>( "Count" );
     sphactor_register( "Log", &LogActor, NULL, NULL );
     sphactor_register<NatNet>( "NatNet" );
+    sphactor_register<OSCInput>( "OSC Input" );
     sphactor_register<Pulse>( "Pulse" );
 
     UpdateRegisteredActorsCache();

--- a/stage.cpp
+++ b/stage.cpp
@@ -65,8 +65,11 @@ void UpdateRegisteredActorsCache() {
 }
 
 void RegisterActors() {
+    //TODO: Rename this actor...
+    sphactor_register<Client>( "Client" );
     sphactor_register<Count>( "Count" );
     sphactor_register( "Log", &LogActor, NULL, NULL );
+    sphactor_register<NatNet>( "NatNet" );
     sphactor_register<Pulse>( "Pulse" );
 
     UpdateRegisteredActorsCache();


### PR DESCRIPTION
NatNet actor basically only opens dgram sockets and allows you to edit the motive ip from its capabilities. I haven't checked the exact ports (so they may be revered 1511/1510)

From here the plan is to build a data parses for whatever we receive, and use the other dgram as the command socket.

OSC Input works when receiving from our UnityOSCToolkit on another PC, so seems OK. Test by dragging its output to a Log node. 