### PR TITLE
Functional NatNet2OSC Draft

### DIFF
--- a/ActorContainer.h
+++ b/ActorContainer.h
@@ -41,7 +41,8 @@ enum GActorSlotTypes
     ActorSlotRotation,
     ActorSlotMatrix,
     ActorSlotInt,
-    ActorSlotOSC
+    ActorSlotOSC,
+    ActorSlotNatNet
 };
 
 struct ActorContainer {
@@ -171,6 +172,9 @@ struct ActorContainer {
             char* typeStr = zconfig_value(type);
             if ( streq(typeStr, "OSC")) {
                 list->push_back({ "OSC", ActorSlotOSC });
+            }
+            else if ( streq(typeStr, "NatNet")) {
+                list->push_back({ "NatNet", ActorSlotNatNet });
             }
             else {
                 zsys_error("Unsupported %s: %s", node, typeStr);

--- a/Actors/ClientActor.cpp
+++ b/Actors/ClientActor.cpp
@@ -4,6 +4,12 @@
 const char * clientCapabilities =
                                 "capabilities\n"
                                 "    data\n"
+                                "        name = \"name\"\n"
+                                "        type = \"string\"\n"
+                                "        value = \"default\"\n"
+                                "        api_call = \"SET NAME\"\n"
+                                "        api_value = \"s\"\n"
+                                "    data\n"
                                 "        name = \"ip\"\n"
                                 "        type = \"string\"\n"
                                 "        value = \"192.168.0.1\"\n"
@@ -71,7 +77,12 @@ zmsg_t* Client::handleMsg( sphactor_event_t * ev ) {
         //pop msg for command
         char * cmd = zmsg_popstr(ev->msg);
         if (cmd) {
-            if ( streq(cmd, "SET PORT") ) {
+            if ( streq(cmd, "SET NAME") ) {
+                char * name = zmsg_popstr(ev->msg);
+                this->name = name;
+                zstr_free(&name);
+            }
+            else if ( streq(cmd, "SET PORT") ) {
                 char * port = zmsg_popstr(ev->msg);
                 this->port = port;
                 std::string url = ("udp://" + this->host + ":" + this->port);

--- a/Actors/ClientActor.cpp
+++ b/Actors/ClientActor.cpp
@@ -52,7 +52,7 @@ zmsg_t* Client::handleMsg( sphactor_event_t * ev ) {
         zframe_t* frame;
 
         do {
-        frame = zmsg_pop(ev->msg);
+            frame = zmsg_pop(ev->msg);
             if ( frame ) {
                 msgBuffer = zframe_data(frame);
                 size_t len = zframe_size(frame);
@@ -62,9 +62,6 @@ zmsg_t* Client::handleMsg( sphactor_event_t * ev ) {
                 int rc = zsock_send(dgrams,  "b", msgBuffer, len);
                 if ( rc != 0 ) {
                     zsys_info("Error sending zosc message to: %s, %i", url.c_str(), rc);
-                }
-                else {
-                    zsys_info( "Sent message to %s", url.c_str());
                 }
             }
         } while (frame != NULL );

--- a/Actors/ClientActor.h
+++ b/Actors/ClientActor.h
@@ -7,6 +7,7 @@
 struct Client {
     zsock_t* dgrams = NULL;
 
+    std::string name = "";
     std::string host = "";
     std::string port = "";
 

--- a/Actors/LogActor.cpp
+++ b/Actors/LogActor.cpp
@@ -13,24 +13,83 @@ zmsg_t * LogActor( sphactor_event_t *ev, void* args ) {
         if ( ev->msg == NULL ) return NULL;
 
         byte *msgBuffer;
-        zframe_t* frame;
+        zframe_t* frame = NULL;
 
         do {
-        frame = zmsg_pop(ev->msg);
+            if ( frame != NULL ) {
+                zframe_destroy(&frame);
+            }
+            frame = zmsg_pop(ev->msg);
             if ( frame ) {
                 //parse zosc_t msg
                 msgBuffer = zframe_data(frame);
                 size_t len = zframe_size(frame);
 
-                //TODO: implement zosc message parsing
                 const char* msg;
                 zosc_t * oscMsg = zosc_frommem( (char*)msgBuffer, len);
+                if ( oscMsg ) {
+                    const char* address = zosc_address(oscMsg);
+                    printf("address: %s", address);
+
+                    char type = '0';
+                    const void *data = zosc_first(oscMsg, &type);
+                    bool name = false;
+                    while( data ) {
+                        switch(type) {
+                            case 's': {
+                                char* value;
+                                int rc = zosc_pop_string(oscMsg, &value);
+                                if( rc == 0)
+                                {
+                                    printf(", %s", value);
+                                    zstr_free(&value);
+                                }
+                            } break;
+                            case 'c': {
+                                char value;
+                                zosc_pop_char(oscMsg, &value);
+                                printf(", %c", value);
+                            } break;
+                            case 'i': {
+                                int32_t value;
+                                zosc_pop_int32(oscMsg, &value);
+                                printf(", %i", value);
+                            } break;
+                            case 'h': {
+                                int64_t value;
+                                zosc_pop_int64(oscMsg, &value);
+                                printf(", %lli", value);
+                            } break;
+                            case 'f': {
+                                float value;
+                                zosc_pop_float(oscMsg, &value);
+                                printf(", %f", value);
+                            } break;
+                            case 'd': {
+                                double value;
+                                zosc_pop_double(oscMsg, &value);
+                                printf(", %f", value);
+                            } break;
+                            case 'F': {
+                                printf(", FALSE");
+                            } break;
+                            case 'T': {
+                                printf(", TRUE");
+                            } break;
+                        }
+
+                        data = zosc_next(oscMsg, &type);
+                    }
+                    printf("\n");
+                }
+
                 zosc_retr( oscMsg, "s", &msg );
 
                 zsys_info("%s: %s", msgBuffer, msg);
             }
         } while (frame != NULL );
 
+        zframe_destroy(&frame);
         zmsg_destroy(&ev->msg);
 
         return NULL;

--- a/Actors/NatNet2OSCActor.cpp
+++ b/Actors/NatNet2OSCActor.cpp
@@ -171,7 +171,7 @@ void NatNet2OSC::addRigidbodies(zmsg_t *zmsg)
         bool found = false;
         for( int r = 0; r < rbHistory.size(); ++r )
         {
-            if ( rbHistory[r].rigidBodyId == RB.id )
+            if ( rbHistory[r].rigidBodyId == rbd.id )
             {
                 rb = &rbHistory[r];
                 found = true;
@@ -180,7 +180,7 @@ void NatNet2OSC::addRigidbodies(zmsg_t *zmsg)
 
         if ( !found )
         {
-            rb = new RigidBodyHistory( RB.id, position, rotation );
+            rb = new RigidBodyHistory( rbd.id, position, rotation );
             rbHistory.push_back(*rb);
         }
 
@@ -250,7 +250,7 @@ void NatNet2OSC::addRigidbodies(zmsg_t *zmsg)
         }
 
         zosc_t *oscMsg = zosc_create(address.c_str(), "isfffffff",
-                                     RB.id,
+                                     rbd.id,
                                      NatNet::rigidbody_descs[i].name.c_str(),
                                      position[0],
                                      position[1],

--- a/Actors/NatNet2OSCActor.cpp
+++ b/Actors/NatNet2OSCActor.cpp
@@ -1,0 +1,106 @@
+#include "libsphactor.h"
+#include "NatNet2OSCActor.h"
+
+//TODO: Add filter options
+const char * natNet2OSCCapabilities = "capabilities\n"
+                                "    data\n"
+                                "        name = \"markers\"\n"
+                                "        type = \"bool\"\n"
+                                "        value = \"False\"\n"
+                                "        api_call = \"SET MARKERS\"\n"
+                                "        api_value = \"s\"\n"
+                                "    data\n"
+                                "        name = \"rigidbodies\"\n"
+                                "        type = \"bool\"\n"
+                                "        value = \"False\"\n"
+                                "        api_call = \"SET RIGIDBODIES\"\n"
+                                "        api_value = \"s\"\n"
+                                "    data\n"
+                                "        name = \"skeletons\"\n"
+                                "        type = \"bool\"\n"
+                                "        value = \"False\"\n"
+                                "        api_call = \"SET SKELETONS\"\n"
+                                "        api_value = \"s\"\n"
+                                "    data\n"
+                                "        name = \"rbVelocities\"\n"
+                                "        type = \"bool\"\n"
+                                "        value = \"False\"\n"
+                                "        api_call = \"SET VELOCITIES\"\n"
+                                "        api_value = \"s\"\n"
+                                "    data\n"
+                                "        name = \"hierarchy\"\n"
+                                "        type = \"bool\"\n"
+                                "        value = \"True\"\n"
+                                "        api_call = \"SET HIERARCHY\"\n"
+                                "        api_value = \"s\"\n"
+                                "    data\n"
+                                "        name = \"sendSkeletonDefinitions\"\n"
+                                "        type = \"bool\"\n"
+                                "        value = \"False\"\n"
+                                "        api_call = \"SET SKELETONDEF\"\n"
+                                "        api_value = \"s\"\n"
+                                "inputs\n"
+                                "    input\n"
+                                "        type = \"OSC\"\n" //TODO: NatNet input?
+                                "outputs\n"
+                                "    output\n"
+                                "        type = \"OSC\"\n";
+
+zmsg_t *
+NatNet2OSC::handleMsg( sphactor_event_t *ev ) {
+    if ( streq(ev->type, "INIT")) {
+        sphactor_actor_set_capability((sphactor_actor_t*)ev->actor, zconfig_str_load(natNet2OSCCapabilities));
+    }
+    else if ( streq( ev->type, "DESTROY")) {
+        delete this;
+        zmsg_destroy(&ev->msg);
+        return NULL;
+    }
+    else if ( streq(ev->type, "SOCK")) {
+        //TODO: unpack msg and parse into OSC
+    }
+    else if ( streq(ev->type, "API")) {
+        //pop msg for command
+        char * cmd = zmsg_popstr(ev->msg);
+        if (cmd) {
+            if ( streq(cmd, "SET MARKERS") ) {
+                char * value = zmsg_popstr(ev->msg);
+                sendMarkers = streq( value, "True");
+                //zsys_info("Got: %s, set to %s", value, sendMarkers ? "True" : "False");
+            }
+            else if ( streq(cmd, "SET RIGIDBODIES") ) {
+                char * value = zmsg_popstr(ev->msg);
+                sendRigidbodies = streq( value, "True");
+                //zsys_info("Got: %s, set to %s", value, sendRigidbodies ? "True" : "False");
+            }
+            else if ( streq(cmd, "SET SKELETONS") ) {
+                char * value = zmsg_popstr(ev->msg);
+                sendSkeletons = streq( value, "True");
+                //zsys_info("Got: %s, set to %s", value, sendSkeletons ? "True" : "False");
+            }
+            else if ( streq(cmd, "SET VELOCITIES") ) {
+                char * value = zmsg_popstr(ev->msg);
+                sendVelocities = streq( value, "True");
+                //zsys_info("Got: %s, set to %s", value, sendVelocities ? "True" : "False");
+            }
+            else if ( streq(cmd, "SET HIERARCHY") ) {
+                char * value = zmsg_popstr(ev->msg);
+                sendHierarchy = streq( value, "True");
+                //zsys_info("Got: %s, set to %s", value, sendHierarchy ? "True" : "False");
+            }
+            else if ( streq(cmd, "SET SKELETONDEF") ) {
+                char * value = zmsg_popstr(ev->msg);
+                sendSkeletonDefinitions = streq( value, "True");
+                //zsys_info("Got: %s, set to %s", value, sendSkeletonDefinitions ? "True" : "False");
+            }
+
+            zstr_free(&cmd);
+        }
+
+        zmsg_destroy(&ev->msg);
+
+        return NULL;
+    }
+
+    return ev->msg;
+}

--- a/Actors/NatNet2OSCActor.cpp
+++ b/Actors/NatNet2OSCActor.cpp
@@ -1,5 +1,7 @@
 #include "libsphactor.h"
 #include "NatNet2OSCActor.h"
+#include "NatNetActor.h"
+#include <map>
 
 //TODO: Add filter options
 const char * natNet2OSCCapabilities = "capabilities\n"
@@ -57,7 +59,42 @@ NatNet2OSC::handleMsg( sphactor_event_t *ev ) {
         return NULL;
     }
     else if ( streq(ev->type, "SOCK")) {
+        zmsg_destroy(&ev->msg);
+
         //TODO: unpack msg and parse into OSC
+        zframe_t *zframe = zmsg_pop(ev->msg);
+        if (zframe) {
+            //TODO: Move Unpack here
+            Unpack((char *) zframe_data(zframe));
+            zframe_destroy(&zframe);
+        }
+
+        //Send Frame
+        zmsg_t* oscMsg = zmsg_new();
+
+        //markers
+        for (int i = 0; i < markers.size(); i++)
+        {
+            zosc_t * osc = zosc_create("/marker", "ifff", i, markers[i][0], markers[i][1], markers[i][2]);
+            zmsg_add(oscMsg, zosc_pack(osc));
+            //TODO: clean up osc* ?
+        }
+
+        //rigidbodies
+        addRigidbodies(oscMsg);
+
+        //skeletons
+        addSkeletons(oscMsg);
+
+        if ( zmsg_content_size(oscMsg) != 0 ){
+            //zsys_info("NatNet: sending data");
+            zmsg_destroy(&ev->msg);
+            return oscMsg;
+        }
+
+        // Nothing to send, destroy and return NULL
+        zmsg_destroy(&oscMsg);
+        return NULL;
     }
     else if ( streq(ev->type, "API")) {
         //pop msg for command
@@ -98,9 +135,780 @@ NatNet2OSC::handleMsg( sphactor_event_t *ev ) {
         }
 
         zmsg_destroy(&ev->msg);
-
         return NULL;
     }
 
     return ev->msg;
+}
+
+void NatNet2OSC::addRigidbodies(zmsg_t *zmsg)
+{
+    for (int i = 0; i < rigidbodies.size(); i++)
+    {
+        RigidBody &RB = rigidbodies[i];
+
+        // Decompose to get the different elements
+        glm::vec3 position = RB.position;
+        glm::quat rotation;
+        rotation.x = RB.rotation[0];
+        rotation.y = RB.rotation[1];
+        rotation.z = RB.rotation[2];
+        rotation.w = RB.rotation[3];
+
+        //we're going to fetch or create this
+        //TODO: TEST re-implemented rigidbody histories for velocity data
+        RigidBodyHistory *rb;
+
+        //Get or create rigidbodyhistory
+        bool found = false;
+        for( int r = 0; r < rbHistory.size(); ++r )
+        {
+            if ( rbHistory[r].rigidBodyId == RB.id )
+            {
+                rb = &rbHistory[r];
+                found = true;
+            }
+        }
+
+        if ( !found )
+        {
+            rb = new RigidBodyHistory( RB.id, position, rotation );
+            rbHistory.push_back(*rb);
+        }
+
+        glm::vec3 velocity;
+        glm::vec3 angularVelocity;
+
+        if ( rb->firstRun )
+        {
+            rb->currentDataPoint = 0;
+            rb->firstRun = false;
+        }
+        else
+        {
+            //TODO: Get invFPS from timeout
+            float invFPS = ( 1.0f / 60.0f );
+            if ( rb->currentDataPoint < 2 * SMOOTHING + 1 )
+            {
+                rb->velocities[rb->currentDataPoint] = ( position - rb->previousPosition ) * invFPS;
+                glm::vec3 diff = glm::eulerAngles( rb->previousOrientation * glm::inverse(rotation) );
+                rb->angularVelocities[rb->currentDataPoint] = ( diff * invFPS );
+
+                rb->currentDataPoint++;
+            }
+            else
+            {
+                int count = 0;
+                int maxDist = SMOOTHING;
+                glm::vec3 totalVelocity;
+                glm::vec3 totalAngularVelocity;
+                //calculate smoothed velocity
+                for( int x = 0; x < SMOOTHING * 2 + 1; ++x )
+                {
+                    //calculate integer distance from "center"
+                    //above - maxDist = influence of data point
+                    int dist = abs( x - SMOOTHING );
+                    int infl = ( maxDist - dist ) + 1;
+
+                    //add all
+                    totalVelocity += rb->velocities[x] * glm::vec3(infl);
+                    totalAngularVelocity += rb->angularVelocities[x] * glm::vec3(infl);
+                    //count "influences"
+                    count += infl;
+                }
+
+                //divide by total data point influences
+                velocity = totalVelocity / glm::vec3(count);
+                angularVelocity = totalAngularVelocity / glm::vec3(count);
+
+                for( int x = 0; x < rb->currentDataPoint - 1; ++x )
+                {
+                    rb->velocities[x] = rb->velocities[x+1];
+                    rb->angularVelocities[x] = rb->angularVelocities[x+1];
+                }
+                rb->velocities[rb->currentDataPoint-1] = ( position - rb->previousPosition ) * invFPS;
+
+                glm::vec3 diff = glm::eulerAngles(( rb->previousOrientation * glm::inverse(rotation) ));
+                rb->angularVelocities[rb->currentDataPoint-1] = ( diff * invFPS );
+            }
+
+            rb->previousPosition = position;
+            rb->previousOrientation = rotation;
+        }
+
+        std::string address = "/rigidbody";
+        if ( sendHierarchy ) {
+            address += "/"+NatNet::rigidbody_descs[i].name;
+        }
+
+        zosc_t *oscMsg = zosc_create(address.c_str(), "isfffffffi",
+                                     RB.id,
+                                     NatNet::rigidbody_descs[i].name.c_str(),
+                                     position[0],
+                                     position[1],
+                                     position[2],
+                                     rotation[0],
+                                     rotation[1],
+                                     rotation[2],
+                                     rotation[3],
+                                     (RB.isActive() ? 1 : 0)
+        );
+
+        if ( sendVelocities )
+        {
+            zosc_append(oscMsg, "fffff",
+                        //velocity over SMOOTHING * 2 + 1 frames
+                        velocity.x * 1000, velocity.y * 1000, velocity.z * 1000,
+                        //angular velocity (euler), also smoothed
+                        angularVelocity.x * 1000, angularVelocity.y * 1000, angularVelocity.z * 1000 );
+        }
+
+
+        zmsg_add(zmsg, zosc_pack(oscMsg));
+    }
+}
+
+void NatNet2OSC::addSkeletons(zmsg_t *zmsg)
+{
+    for (int j = 0; j < skeletons.size(); j++)
+    {
+        const Skeleton &S = skeletons[j];
+        std::vector<RigidBodyDescription> rbd = NatNet::skeleton_descs[j].joints;
+
+        if ( sendHierarchy )
+        {
+            for (int i = 0; i < S.joints.size(); i++)
+            {
+                RigidBody RB = S.joints[i];
+                std::string address = "/skeleton/" + NatNet::skeleton_descs[j].name + "/" + rbd[i].name;
+
+                // Get the matirx
+                //ofMatrix4x4 matrix = RB.matrix;
+
+                // Decompose to get the different elements
+                //Vec3 position;
+                //Vec4 rotation;
+                //Vec3 scale;
+                //Vec4 so;
+                //matrix.decompose(position, rotation, scale, so);
+
+                zosc_t *oscMsg = zosc_create( address.c_str(), "sfffffff",
+                                              rbd[i].name.c_str(),
+                                              RB.position[0],
+                                              RB.position[1],
+                                              RB.position[2],
+                                              RB.rotation[0],
+                                              RB.rotation[1],
+                                              RB.rotation[2],
+                                              RB.rotation[3]
+                );
+
+                //needed for skeleton retargeting
+                if ( sendSkeletonDefinitions )
+                {
+                    zosc_append(oscMsg, "ifff",
+                                rbd[i].parent_id,
+                                rbd[i].offset[0],
+                                rbd[i].offset[1],
+                                rbd[i].offset[2]
+                    );
+                }
+
+                zmsg_add(zmsg, zosc_pack(oscMsg));
+            }
+        }
+        else
+        {
+            std::string address = "/skeleton";
+
+            zosc_t * oscMsg = zosc_create(address.c_str(), "si", NatNet::skeleton_descs[j].name.c_str(), S.id );
+
+            for (int i = 0; i < S.joints.size(); i++)
+            {
+                RigidBody RB = S.joints[i];
+
+                // Get the matirx
+                //ofMatrix4x4 matrix = RB.matrix;
+
+                // Decompose to get the different elements
+                //ofVec3f position;
+                //ofQuaternion rotation;
+                //ofVec3f scale;
+                //ofQuaternion so;
+                //matrix.decompose(position, rotation, scale, so);
+
+                zosc_append( oscMsg, "sfffffff",
+                             rbd[i].name.c_str(),
+                             RB.position[0],
+                             RB.position[1],
+                             RB.position[2],
+                             RB.rotation[0],
+                             RB.rotation[1],
+                             RB.rotation[2],
+                             RB.rotation[3]
+                );
+
+                //needed for skeleton retargeting
+                if ( sendSkeletonDefinitions )
+                {
+                    zosc_append(oscMsg, "ifff",
+                                rbd[i].parent_id,
+                                rbd[i].offset[0],
+                                rbd[i].offset[1],
+                                rbd[i].offset[2]
+                    );
+                }
+            }
+
+            zmsg_add(zmsg, zosc_pack(oscMsg));
+        }
+    }
+}
+
+char* NatNet2OSC::unpackMarkerSet(char* ptr, std::vector<Marker>& ref_markers)
+{
+    int nMarkers = 0;
+    memcpy(&nMarkers, ptr, 4);
+    ptr += 4;
+
+    ref_markers.resize(nMarkers);
+
+    for (int j = 0; j < nMarkers; j++)
+    {
+        Marker p;
+        memcpy(&p[0], ptr, 4);
+        ptr += 4;
+        memcpy(&p[1], ptr, 4);
+        ptr += 4;
+        memcpy(&p[2], ptr, 4);
+        ptr += 4;
+
+        //TODO: Matrix, only used for scale previously
+        //p = transform.preMult(p);
+
+        ref_markers[j] = p;
+    }
+
+    return ptr;
+}
+
+char* NatNet2OSC::unpackRigidBodies(char* ptr, std::vector<RigidBody>& ref_rigidbodies)
+{
+    //TODO: Access static natnet vars
+    int major = NatNet::NatNetVersion[0];
+    int minor = NatNet::NatNetVersion[1];
+
+    //TODO: Matrix, only used for scale previously
+    //ofQuaternion rot = transform.getRotate();
+
+    int nRigidBodies = 0;
+    memcpy(&nRigidBodies, ptr, 4);
+    ptr += 4;
+
+    ref_rigidbodies.resize(nRigidBodies);
+
+    for (int j = 0; j < nRigidBodies; j++)
+    {
+        RigidBody& RB = ref_rigidbodies[j];
+
+        glm::vec3 pp;
+        glm::vec4 q;
+
+        int ID = 0;
+        memcpy(&ID, ptr, 4);
+        ptr += 4;
+
+        memcpy(&pp[0], ptr, 4);
+        ptr += 4;
+
+        memcpy(&pp[1], ptr, 4);
+        ptr += 4;
+
+        memcpy(&pp[2], ptr, 4);
+        ptr += 4;
+
+        memcpy(&q[0], ptr, 4);
+        ptr += 4;
+
+        memcpy(&q[1], ptr, 4);
+        ptr += 4;
+
+        memcpy(&q[2], ptr, 4);
+        ptr += 4;
+
+        memcpy(&q[3], ptr, 4);
+        ptr += 4;
+
+        RB.id = ID;
+        RB.position = pp;
+        RB.rotation = q;
+
+        //TODO: Matrix, only used for scale previously
+        //pp = transform.preMult(pp);
+        //
+        //ofMatrix4x4 mat;
+        //mat.setTranslation(pp);
+        //mat.setRotate(q * rot);
+        //RB.matrix = mat;
+
+        // associated marker positions
+        int nRigidMarkers = 0;
+        memcpy(&nRigidMarkers, ptr, 4);
+        ptr += 4;
+
+        int nBytes = nRigidMarkers * 3 * sizeof(float);
+        float* markerData = (float*)malloc(nBytes);
+        memcpy(markerData, ptr, nBytes);
+        ptr += nBytes;
+
+        if (major >= 2)
+        {
+            // associated marker IDs
+            nBytes = nRigidMarkers * sizeof(int);
+            ptr += nBytes;
+
+            // associated marker sizes
+            nBytes = nRigidMarkers * sizeof(float);
+            ptr += nBytes;
+        }
+
+        RB.markers.resize(nRigidMarkers);
+
+        for (int k = 0; k < nRigidMarkers; k++)
+        {
+            float x = markerData[k * 3];
+            float y = markerData[k * 3 + 1];
+            float z = markerData[k * 3 + 2];
+
+            glm::vec3 pp(x, y, z);
+            //TODO: Matrix, only used for scale previously
+            //pp = transform.preMult(pp);
+            RB.markers[k] = pp;
+        }
+
+        if (markerData) free(markerData);
+
+        if (major >= 2)
+        {
+            // Mean marker error
+            float fError = 0.0f;
+            memcpy(&fError, ptr, 4);
+            ptr += 4;
+
+            RB.mean_marker_error = fError;
+            RB._active = RB.mean_marker_error > 0;
+        } else {
+            RB.mean_marker_error = 0;
+        }
+
+        // 2.6 and later
+        if (((major == 2) && (minor >= 6)) || (major > 2) || (major == 0))
+        {
+            // params
+            short params = 0; memcpy(&params, ptr, 2); ptr += 2;
+            bool bTrackingValid = params & 0x01; // 0x01 : rigid body was successfully tracked in this frame
+        }
+
+    }  // next rigid body
+
+    return ptr;
+}
+
+void NatNet2OSC::Unpack( char * pData ) {
+    int major = NatNet::NatNetVersion[0];
+    int minor = NatNet::NatNetVersion[1];
+
+    //TODO: Matrix, only used for scale previously
+    //Vec4 rotation = transform.getRotate();
+
+    char *ptr = pData;
+
+    //zsys_info("Begin Packet\n-------\n");
+
+    // message ID
+    int MessageID = 0;
+    memcpy(&MessageID, ptr, 2); ptr += 2;
+    //zsys_info("Message ID : %d\n", MessageID);
+
+    // size
+    int nBytes = 0;
+    memcpy(&nBytes, ptr, 2); ptr += 2;
+    //zsys_info("Byte count : %d\n", nBytes);
+
+    if(MessageID == 7)      // FRAME OF MOCAP DATA packet
+    {
+        // temporary data containers
+        std::vector<std::vector<Marker> > tmp_markers_set;
+        std::vector<Skeleton> tmp_skeletons;
+        std::vector<Marker> tmp_markers;
+        std::vector<Marker> tmp_filtered_markers;
+        std::vector<RigidBody> tmp_rigidbodies;
+
+        // frame number
+        int frameNumber = 0; memcpy(&frameNumber, ptr, 4); ptr += 4;
+        //zsys_info("Frame # : %d\n", frameNumber);
+
+        // number of data sets (markersets, rigidbodies, etc)
+        int nMarkerSets = 0; memcpy(&nMarkerSets, ptr, 4); ptr += 4;
+        //zsys_info("Marker Set Count : %d\n", nMarkerSets);
+
+        tmp_markers_set.resize(nMarkerSets);
+
+        for (int i=0; i < nMarkerSets; i++)
+        {
+            // Markerset name
+            char szName[256];
+            strcpy(szName, ptr);
+            int nDataBytes = (int) strlen(szName) + 1;
+            ptr += nDataBytes;
+            //zsys_info("Model Name: %s\n", szName);
+
+            ptr = unpackMarkerSet(ptr, tmp_markers_set[i]);
+        }
+
+        // unidentified markers
+        ptr = unpackMarkerSet(ptr, tmp_markers);
+
+        // rigid bodies
+        ptr = unpackRigidBodies(ptr, tmp_rigidbodies);
+
+        // skeletons (version 2.1 and later)
+        if( ((major == 2)&&(minor>0)) || (major>2))
+        {
+            int nSkeletons = 0;
+            memcpy(&nSkeletons, ptr, 4); ptr += 4;
+            //zsys_info("Skeleton Count : %d\n", nSkeletons);
+
+            tmp_skeletons.resize(nSkeletons);
+
+            for (int j=0; j < nSkeletons; j++)
+            {
+                // skeleton id
+                int skeletonID = 0;
+                memcpy(&skeletonID, ptr, 4); ptr += 4;
+
+                tmp_skeletons[j].id = skeletonID;
+
+                ptr = unpackRigidBodies(ptr, tmp_skeletons[j].joints);
+            } // next skeleton
+        }
+
+        // labeled markers (version 2.3 and later)
+        if( ((major == 2)&&(minor>=3)) || (major>2))
+        {
+            int nLabeledMarkers = 0;
+            memcpy(&nLabeledMarkers, ptr, 4); ptr += 4;
+            //zsys_info("Labeled Marker Count : %d\n", nLabeledMarkers);
+            for (int j=0; j < nLabeledMarkers; j++)
+            {
+                // id
+                int ID = 0; memcpy(&ID, ptr, 4); ptr += 4;
+                // x
+                float x = 0.0f; memcpy(&x, ptr, 4); ptr += 4;
+                // y
+                float y = 0.0f; memcpy(&y, ptr, 4); ptr += 4;
+                // z
+                float z = 0.0f; memcpy(&z, ptr, 4); ptr += 4;
+                // size
+                float size = 0.0f; memcpy(&size, ptr, 4); ptr += 4;
+
+                // 2.6 and later
+                if( ((major == 2)&&(minor >= 6)) || (major > 2) || (major == 0) )
+                {
+                    // marker params
+                    short params = 0; memcpy(&params, ptr, 2); ptr += 2;
+                    bool bOccluded = params & 0x01;     // marker was not visible (occluded) in this frame
+                    bool bPCSolved = params & 0x02;     // position provided by point cloud solve
+                    bool bModelSolved = params & 0x04;  // position provided by model solve
+                }
+
+                //zsys_info("ID  : %d\n", ID);
+                //zsys_info("pos : [%3.2f,%3.2f,%3.2f]\n", x,y,z);
+                //zsys_info("size: [%3.2f]\n", size);
+
+                glm::vec3 pp(x, y, z);
+                //TODO: Matrix, only used for scale previously
+                //pp = transform.preMult(pp);
+                tmp_markers.push_back(pp);
+            }
+        }
+
+        // Force Plate data (version 2.9 and later)
+        if (((major == 2) && (minor >= 9)) || (major > 2))
+        {
+            int nForcePlates;
+            memcpy(&nForcePlates, ptr, 4); ptr += 4;
+            for (int iForcePlate = 0; iForcePlate < nForcePlates; iForcePlate++)
+            {
+                // ID
+                int ID = 0; memcpy(&ID, ptr, 4); ptr += 4;
+                //zsys_info("Force Plate : %d\n", ID);
+
+                // Channel Count
+                int nChannels = 0; memcpy(&nChannels, ptr, 4); ptr += 4;
+
+                // Channel Data
+                for (int i = 0; i < nChannels; i++)
+                {
+                    //zsys_info(" Channel %d : ", i);
+                    int nFrames = 0; memcpy(&nFrames, ptr, 4); ptr += 4;
+                    for (int j = 0; j < nFrames; j++)
+                    {
+                        float val = 0.0f;  memcpy(&val, ptr, 4); ptr += 4;
+                        //zsys_info("%3.2f   ", val);
+                    }
+                    //zsys_info("\n");
+                }
+            }
+        }
+
+        // latency
+        float latency = 0.0f; memcpy(&latency, ptr, 4);	ptr += 4;
+        //zsys_info("latency : %3.3f\n", latency);
+        this->latency = latency;
+
+        // timecode
+        unsigned int timecode = 0; 	memcpy(&timecode, ptr, 4);	ptr += 4;
+        unsigned int timecodeSub = 0; memcpy(&timecodeSub, ptr, 4); ptr += 4;
+        char szTimecode[128] = "";
+        TimecodeStringify(timecode, timecodeSub, szTimecode, 128);
+
+        // timestamp
+        double timestamp = 0.0f;
+        // 2.7 and later - increased from single to double precision
+        if( ((major == 2)&&(minor>=7)) || (major>2))
+        {
+            memcpy(&timestamp, ptr, 8); ptr += 8;
+        }
+        else
+        {
+            float fTemp = 0.0f;
+            memcpy(&fTemp, ptr, 4); ptr += 4;
+            timestamp = (double)fTemp;
+        }
+
+        // frame params
+        short params = 0;  memcpy(&params, ptr, 2); ptr += 2;
+        bool bIsRecording = params & 0x01;                  // 0x01 Motive is recording
+        bool bTrackedModelsChanged = params & 0x02;         // 0x02 Actively tracked model list has changed
+
+
+        // end of data tag
+        int eod = 0; memcpy(&eod, ptr, 4); ptr += 4;
+        //zsys_info("End Packet\n-------------\n");
+
+        // filter markers
+        // TODO: Test re-implemented marker filtering (replaced remove_dups)
+        if (duplicated_point_removal_distance > 0)
+        {
+            std::map<int, RigidBody>::iterator it =
+                    this->rigidbodies.begin();
+            while (it != this->rigidbodies.end())
+            {
+                RigidBody& RB = it->second;
+
+                for (int i = 0; i < RB.markers.size(); i++)
+                {
+                    glm::vec3& v = RB.markers[i];
+                    std::vector<Marker>::iterator it = std::remove_if(
+                            tmp_filtered_markers.begin(), tmp_filtered_markers.end(),
+                            remove_dups(v, duplicated_point_removal_distance));
+                    tmp_filtered_markers.erase(it, tmp_filtered_markers.end());
+                }
+
+                it++;
+            }
+        }
+
+        //Copy data to instance...
+        this->latency = latency;
+        this->frame_number = frameNumber;
+        this->markers_set = tmp_markers_set;
+        this->markers = tmp_markers;
+        this->filtered_markers = tmp_filtered_markers;
+
+        // fill the rigidbodies map
+        {
+            for (int i = 0; i < tmp_rigidbodies.size(); i++) {
+                RigidBody &RB = tmp_rigidbodies[i];
+                RigidBody &tRB = this->rigidbodies[RB.id];
+                tRB = RB;
+            }
+        }
+        {
+            for (int i = 0; i < tmp_skeletons.size(); i++) {
+                Skeleton &S = tmp_skeletons[i];
+                Skeleton &tS = this->skeletons[S.id];
+                tS = S;
+            }
+        }
+    }
+    // this is stored centrally on static NatNet:: lists
+    else if(MessageID == 5) // Data Descriptions
+    {
+        //std::vector<RigidBodyDescription> tmp_rigidbody_descs;
+        //std::vector<SkeletonDescription> tmp_skeleton_descs;
+        //std::vector<MarkerSetDescription> tmp_markerset_descs;
+
+        // number of datasets
+        int nDatasets = 0; memcpy(&nDatasets, ptr, 4);
+        ptr += 4;
+        //zsys_info("Dataset Count : %d\n", nDatasets);
+
+        for(int i=0; i < nDatasets; i++)
+        {
+            //zsys_info("Dataset %d\n", i);
+
+            int type = 0; memcpy(&type, ptr, 4); ptr += 4;
+            //zsys_info("Type : %d\n", i, type);
+
+            if(type == 0)   // markerset
+            {
+                //MarkerSetDescription description;
+
+                // name
+                char szName[256];
+                strcpy(szName, ptr);
+                int nDataBytes = (int) strlen(szName) + 1;
+                ptr += nDataBytes;
+                //zsys_info("Markerset Name: %s\n", szName);
+                //description.name = szName;
+
+                // marker data
+                int nMarkers = 0; memcpy(&nMarkers, ptr, 4); ptr += 4;
+                //zsys_info("Marker Count : %d\n", nMarkers);
+
+                for(int j=0; j < nMarkers; j++)
+                {
+                    char szName[256];
+                    strcpy(szName, ptr);
+                    int nDataBytes = (int) strlen(szName) + 1;
+                    ptr += nDataBytes;
+                    //zsys_info("Marker Name: %s\n", szName);
+                    //description.marker_names.push_back(szName);
+                }
+                //tmp_markerset_descs.push_back(description);
+            }
+            else if(type ==1)   // rigid body
+            {
+                //RigidBodyDescription description;
+
+                if(major >= 2)
+                {
+                    // name
+                    char szName[MAX_NAMELENGTH];
+                    strcpy(szName, ptr);
+                    ptr += strlen(ptr) + 1;
+                    //zsys_info("Name: %s\n", szName);
+                    //description.name = szName;
+                }
+
+                int ID = 0; memcpy(&ID, ptr, 4); ptr +=4;
+                //zsys_info("ID : %d\n", ID);
+                //description.id = ID;
+
+                int parentID = 0; memcpy(&parentID, ptr, 4); ptr +=4;
+                //zsys_info("Parent ID : %d\n", parentID);
+                //description.parent_id = parentID;
+
+                float xoffset = 0; memcpy(&xoffset, ptr, 4); ptr +=4;
+                //zsys_info("X Offset : %3.2f\n", xoffset);
+
+                float yoffset = 0; memcpy(&yoffset, ptr, 4); ptr +=4;
+                //zsys_info("Y Offset : %3.2f\n", yoffset);
+
+                float zoffset = 0; memcpy(&zoffset, ptr, 4); ptr +=4;
+                //zsys_info("Z Offset : %3.2f\n", zoffset);
+
+                //description.offset[0] = xoffset;
+                //description.offset[1] = xoffset;
+                //description.offset[2] = xoffset;
+
+                //tmp_rigidbody_descs.push_back(description);
+            }
+            else if(type ==2)   // skeleton
+            {
+                //SkeletonDescription description;
+
+                char szName[MAX_NAMELENGTH];
+                strcpy(szName, ptr);
+                ptr += strlen(ptr) + 1;
+                //zsys_info("Name: %s\n", szName);
+                //description.name = szName;
+
+                int ID = 0; memcpy(&ID, ptr, 4); ptr +=4;
+                //zsys_info("ID : %d\n", ID);
+                //description.id = ID;
+
+                int nRigidBodies = 0; memcpy(&nRigidBodies, ptr, 4); ptr +=4;
+                //zsys_info("RigidBody (Bone) Count : %d\n", nRigidBodies);
+                //description.joints.resize(nRigidBodies);
+
+                for(int i=0; i< nRigidBodies; i++)
+                {
+                    if(major >= 2)
+                    {
+                        // RB name
+                        char szName[MAX_NAMELENGTH];
+                        strcpy(szName, ptr);
+                        ptr += strlen(ptr) + 1;
+                        //zsys_info("Rigid Body Name: %s\n", szName);
+                        //description.joints[i].name = szName;
+                    }
+
+                    int ID = 0; memcpy(&ID, ptr, 4); ptr +=4;
+                    //zsys_info("RigidBody ID : %d\n", ID);
+                    //description.joints[i].id = ID;
+
+                    int parentID = 0; memcpy(&parentID, ptr, 4); ptr +=4;
+                    //zsys_info("Parent ID : %d\n", parentID);
+                    //description.joints[i].parent_id = parentID;
+
+                    float xoffset = 0; memcpy(&xoffset, ptr, 4); ptr +=4;
+                    //zsys_info("X Offset : %3.2f\n", xoffset);
+
+                    float yoffset = 0; memcpy(&yoffset, ptr, 4); ptr +=4;
+                    //zsys_info("Y Offset : %3.2f\n", yoffset);
+
+                    float zoffset = 0; memcpy(&zoffset, ptr, 4); ptr +=4;
+                    //zsys_info("Z Offset : %3.2f\n", zoffset);
+
+                    //description.joints[i].offset[0] = xoffset;
+                    //description.joints[i].offset[0] = yoffset;
+                    //description.joints[i].offset[0] = zoffset;
+                }
+                //tmp_skeleton_descs.push_back(description);
+            }
+
+        }   // next dataset
+
+        //zsys_info("End Packet\n-------------\n");
+
+        //Store descriptions, skipped here
+        //this->markerset_descs = tmp_markerset_descs;
+        //this->rigidbody_descs = tmp_rigidbody_descs;
+        //this->skeleton_descs = tmp_skeleton_descs;
+    }
+    else
+    {
+        zsys_info("Unrecognized Packet Type.\n");
+    }
+}
+
+void NatNet2OSC::fixRanges( glm::vec3 *euler )
+{
+    if (euler->x < -180.0f)
+        euler->x += 360.0f;
+    else if (euler->x > 180.0f)
+        euler->x -= 360.0f;
+
+    if (euler->y < -180.0f)
+        euler->y += 360.0f;
+    else if (euler->y > 180.0f)
+        euler->y -= 360.0f;
+
+    if (euler->z < -180.0f)
+        euler->z += 360.0f;
+    else if (euler->z > 180.0f)
+        euler->z -= 360.0f;
 }

--- a/Actors/NatNet2OSCActor.cpp
+++ b/Actors/NatNet2OSCActor.cpp
@@ -252,13 +252,13 @@ void NatNet2OSC::addRigidbodies(zmsg_t *zmsg)
         zosc_t *oscMsg = zosc_create(address.c_str(), "isfffffff",
                                      rbd.id,
                                      NatNet::rigidbody_descs[i].name.c_str(),
-                                     position[0],
-                                     position[1],
-                                     position[2],
-                                     rotation[0],
-                                     rotation[1],
-                                     rotation[2],
-                                     rotation[3]
+                                     position.x,
+                                     position.y,
+                                     position.z,
+                                     rotation.x,
+                                     rotation.y,
+                                     rotation.z,
+                                     rotation.w
         );
 
         if ( sendVelocities )
@@ -270,7 +270,7 @@ void NatNet2OSC::addRigidbodies(zmsg_t *zmsg)
                         angularVelocity.x * 1000, angularVelocity.y * 1000, angularVelocity.z * 1000 );
         }
 
-        zosc_append(oscMsg, "ii", (RB.isActive() ? 1 : 0), 0 );
+        zosc_append(oscMsg, "i", (RB.isActive() ? 1 : 0));
 
         zmsg_add(zmsg, zosc_pack(oscMsg));
     }
@@ -302,13 +302,13 @@ void NatNet2OSC::addSkeletons(zmsg_t *zmsg)
 
                 zosc_t *oscMsg = zosc_create( address.c_str(), "sfffffff",
                                               rbd[i].name.c_str(),
-                                              RB.position[0],
-                                              RB.position[1],
-                                              RB.position[2],
-                                              RB.rotation[0],
-                                              RB.rotation[1],
-                                              RB.rotation[2],
-                                              RB.rotation[3]
+                                              RB.position.x,
+                                              RB.position.y,
+                                              RB.position.z,
+                                              RB.rotation.x,
+                                              RB.rotation.y,
+                                              RB.rotation.z,
+                                              RB.rotation.w
                 );
 
                 //needed for skeleton retargeting
@@ -316,9 +316,9 @@ void NatNet2OSC::addSkeletons(zmsg_t *zmsg)
                 {
                     zosc_append(oscMsg, "ifff",
                                 rbd[i].parent_id,
-                                rbd[i].offset[0],
-                                rbd[i].offset[1],
-                                rbd[i].offset[2]
+                                rbd[i].offset.x,
+                                rbd[i].offset.y,
+                                rbd[i].offset.z
                     );
                 }
 
@@ -347,13 +347,13 @@ void NatNet2OSC::addSkeletons(zmsg_t *zmsg)
 
                 zosc_append( oscMsg, "sfffffff",
                              rbd[i].name.c_str(),
-                             RB.position[0],
-                             RB.position[1],
-                             RB.position[2],
-                             RB.rotation[0],
-                             RB.rotation[1],
-                             RB.rotation[2],
-                             RB.rotation[3]
+                             RB.position.x,
+                             RB.position.y,
+                             RB.position.z,
+                             RB.rotation.x,
+                             RB.rotation.y,
+                             RB.rotation.z,
+                             RB.rotation.w
                 );
 
                 //needed for skeleton retargeting
@@ -361,9 +361,9 @@ void NatNet2OSC::addSkeletons(zmsg_t *zmsg)
                 {
                     zosc_append(oscMsg, "ifff",
                                 rbd[i].parent_id,
-                                rbd[i].offset[0],
-                                rbd[i].offset[1],
-                                rbd[i].offset[2]
+                                rbd[i].offset.x,
+                                rbd[i].offset.y,
+                                rbd[i].offset.z
                     );
                 }
             }

--- a/Actors/NatNet2OSCActor.cpp
+++ b/Actors/NatNet2OSCActor.cpp
@@ -726,7 +726,6 @@ void NatNet2OSC::Unpack( char * pData ) {
         this->markers_set = tmp_markers_set;
         this->markers = tmp_markers;
         this->filtered_markers = tmp_filtered_markers;
-
         // fill the rigidbodies map
         {
             for (int i = 0; i < tmp_rigidbodies.size(); i++) {

--- a/Actors/NatNet2OSCActor.cpp
+++ b/Actors/NatNet2OSCActor.cpp
@@ -54,7 +54,9 @@ NatNet2OSC::handleMsg( sphactor_event_t *ev ) {
         sphactor_actor_set_capability((sphactor_actor_t*)ev->actor, zconfig_str_load(natNet2OSCCapabilities));
     }
     else if ( streq( ev->type, "DESTROY")) {
-        delete this;
+        //TODO: Figure out why this delete sometimes causes SIGABRT
+        //          "pointer freed was never allocated"
+        //delete this;
         zmsg_destroy(&ev->msg);
         return NULL;
     }
@@ -67,14 +69,6 @@ NatNet2OSC::handleMsg( sphactor_event_t *ev ) {
             byte *data = zframe_data(zframe);
             Unpack((char **) &data);
             zframe_destroy(&zframe);
-
-            //build report
-            zosc_t * msg = zosc_create("/report", "sisisi",
-                                       "Markers", markers.size(),
-                                       "Rigidbodies", rigidbodies.size(),
-                                       "Skeletons", skeletons.size());
-
-            sphactor_actor_set_custom_report_data( (sphactor_actor_t*)ev->actor, msg );
 
             //Send Frame
             zmsg_t *oscMsg = zmsg_new();

--- a/Actors/NatNet2OSCActor.cpp
+++ b/Actors/NatNet2OSCActor.cpp
@@ -87,8 +87,6 @@ NatNet2OSC::handleMsg( sphactor_event_t *ev ) {
         addSkeletons(oscMsg);
 
         if ( zmsg_content_size(oscMsg) != 0 ){
-            //zsys_info("NatNet: sending data");
-            zmsg_destroy(&ev->msg);
             return oscMsg;
         }
 

--- a/Actors/NatNet2OSCActor.h
+++ b/Actors/NatNet2OSCActor.h
@@ -29,7 +29,7 @@ struct NatNet2OSC {
     zmsg_t *handleMsg( sphactor_event_t *ev );
 
     //NatNet parse functions
-    void Unpack( char * pData );
+    void Unpack( char ** pData );
     char* unpackRigidBodies(char* ptr, std::vector<RigidBody>& ref_rigidbodies);
     char* unpackMarkerSet(char* ptr, std::vector<Marker>& ref_markers);
     void sendRequestDescription();

--- a/Actors/NatNet2OSCActor.h
+++ b/Actors/NatNet2OSCActor.h
@@ -1,0 +1,21 @@
+#ifndef GAZEBOSC_NATNET2OSCACTOR_H
+#define GAZEBOSC_NATNET2OSCACTOR_H
+
+struct NatNet2OSC {
+    bool sendMarkers = false;
+    bool sendRigidbodies = false;
+    bool sendSkeletons = false;
+    bool sendSkeletonDefinitions = false;
+    bool sendVelocities = false;
+    bool sendHierarchy = true;
+
+    zmsg_t *handleMsg( sphactor_event_t *ev );
+
+    NatNet2OSC() {
+    }
+
+    ~NatNet2OSC() {
+    }
+};
+
+#endif //GAZEBOSC_NATNET2OSCACTOR_H

--- a/Actors/NatNet2OSCActor.h
+++ b/Actors/NatNet2OSCActor.h
@@ -1,6 +1,9 @@
 #ifndef GAZEBOSC_NATNET2OSCACTOR_H
 #define GAZEBOSC_NATNET2OSCACTOR_H
 
+#include "NatNetDataTypes.h"
+#include <map>
+
 struct NatNet2OSC {
     bool sendMarkers = false;
     bool sendRigidbodies = false;
@@ -9,7 +12,32 @@ struct NatNet2OSC {
     bool sendVelocities = false;
     bool sendHierarchy = true;
 
+    int frame_number;
+    float latency;
+    float timeout;
+    int sentRequest;
+    float duplicated_point_removal_distance = 0;
+
+    std::vector<std::vector<Marker> > markers_set;
+    std::vector<Marker> filtered_markers;
+    std::vector<Marker> markers;
+    std::map<int, RigidBody> rigidbodies;
+    std::map<int, Skeleton> skeletons;
+
+    std::vector<RigidBodyHistory> rbHistory;
+
     zmsg_t *handleMsg( sphactor_event_t *ev );
+
+    //NatNet parse functions
+    void Unpack( char * pData );
+    char* unpackRigidBodies(char* ptr, std::vector<RigidBody>& ref_rigidbodies);
+    char* unpackMarkerSet(char* ptr, std::vector<Marker>& ref_markers);
+    void sendRequestDescription();
+
+    //OSC Sending Functions
+    void addRigidbodies(zmsg_t *zmsg);
+    void addSkeletons(zmsg_t *zmsg);
+    void fixRanges( glm::vec3 *euler );
 
     NatNet2OSC() {
     }

--- a/Actors/NatNetActor.cpp
+++ b/Actors/NatNetActor.cpp
@@ -204,7 +204,9 @@ zmsg_t * NatNet::handleMsg( sphactor_event_t * ev ) {
                 else if ( sockFD == dataFD ) {
                     zsys_info("DATA SOCKET");
 
-                    // Parse packet
+                    //TODO: Send data packet to connected natnet2osc clients
+                    //          this will allow for multiple filters
+                    //Parse packet
                     zmsg_t* zmsg = zmsg_recv(DataSocket);
                     if ( zmsg ) {
                         zframe_t *zframe = zmsg_pop(zmsg);

--- a/Actors/NatNetActor.cpp
+++ b/Actors/NatNetActor.cpp
@@ -151,14 +151,17 @@ zmsg_t * NatNet::handleMsg( sphactor_event_t * ev ) {
                     //Parse packet
                     zmsg_t* zmsg = zmsg_recv(DataSocket);
 
+                    // We're still unpacking the data here because it might contain definitions we need to store
+                    // TODO: Find a way to optimize getting definitions
                     if ( zmsg ) {
-                        return zmsg;
-                        //zframe_t *zframe = zmsg_pop(zmsg);
-                        //if (zframe) {
-                        //    Unpack((char *) zframe_data(zframe));
-                        //    zframe_destroy(&zframe);
-                        //}
+                        zframe_t *zframe = zmsg_pop(zmsg);
+                        if (zframe) {
+                            Unpack((char *) zframe_data(zframe));
+                            //zframe_destroy(&zframe);
+                        }
                         //zmsg_destroy(&zmsg);
+
+                        return zmsg;
                     }
 
                     return NULL;
@@ -598,8 +601,6 @@ void NatNet::Unpack( char * pData ) {
         this->markers_set = tmp_markers_set;
         this->markers = tmp_markers;
         this->filtered_markers = tmp_filtered_markers;
-        //this->rigidbodies_arr = tmp_rigidbodies;
-        //this->skeletons_arr = tmp_skeletons;
 
         // fill the rigidbodies map
         {

--- a/Actors/NatNetActor.cpp
+++ b/Actors/NatNetActor.cpp
@@ -36,8 +36,8 @@ zmsg_t * NatNet::handleMsg( sphactor_event_t * ev ) {
         //receive socket on port DATA_PORT
         //Test multicast group to receive data
         //TODO: Discover network interfaces, and have user select which to bind (drop-down)
-        //         Currently you'l have to always multicast receive on your primary address
-        //          So if you want to something else, manually add "ip;" after "udp://"
+        //         This might multicast receive on the wrong interface (OS primary)
+        //          So if you want to try another one, manually add "ip;" after "udp://"
         //              example: "udp://192.168.10.124;..."
         std::string url = "udp://" + MULTICAST_ADDRESS + ":" + PORT_DATA_STR;
         DataSocket = zsock_new(ZMQ_DGRAM);
@@ -70,6 +70,8 @@ zmsg_t * NatNet::handleMsg( sphactor_event_t * ev ) {
             dataFD = -1;
         }
 
+        //TODO: Figure out why this delete sometimes causes SIGABRT
+        //          "pointer freed was never allocated"
         //delete this; ?? SIGABRT ??
         zmsg_destroy(&ev->msg);
         return NULL;

--- a/Actors/NatNetActor.h
+++ b/Actors/NatNetActor.h
@@ -23,6 +23,8 @@ struct NatNet {
     // NatNet vars
     static int* NatNetVersion;// = {0,0,0,0};
     static int* ServerVersion;// = {0,0,0,0};
+    bool rigidbodiesReady = true;
+    bool skeletonsReady = true;
 
     int gCommandResponse = 0;
     int gCommandResponseSize = 0;
@@ -52,7 +54,7 @@ struct NatNet {
     int SendCommand(char* szCOmmand);
     void HandleCommand(sPacket *PacketIn);
 
-    void Unpack( char * pData );
+    void Unpack( char ** pData );
     char* unpackRigidBodies(char* ptr, std::vector<RigidBody>& ref_rigidbodies);
     char* unpackMarkerSet(char* ptr, std::vector<Marker>& ref_markers);
     void sendRequestDescription();

--- a/Actors/NatNetActor.h
+++ b/Actors/NatNetActor.h
@@ -20,18 +20,9 @@ struct NatNet {
     // ServerAddress
     std::string host = "";
 
-    // Temporary settings for feature parity
-    // TODO: Move these to a filter node? Figure out how to share the natnet data efficiently
-    bool sendMarkers = false;
-    bool sendRigidbodies = false;
-    bool sendSkeletons = false;
-    bool sendSkeletonDefinitions = false;
-    bool sendVelocities = false;
-    bool sendHierarchy = true;
-
     // NatNet vars
-    int NatNetVersion[4] = {0,0,0,0};
-    int ServerVersion[4] = {0,0,0,0};
+    static int* NatNetVersion;// = {0,0,0,0};
+    static int* ServerVersion;// = {0,0,0,0};
 
     int gCommandResponse = 0;
     int gCommandResponseSize = 0;
@@ -49,40 +40,30 @@ struct NatNet {
     std::vector<Marker> markers;
 
     std::map<int, RigidBody> rigidbodies;
-    std::vector<RigidBody> rigidbodies_arr;
-
     std::map<int, Skeleton> skeletons;
-    std::vector<Skeleton> skeletons_arr;
 
-    std::vector<RigidBodyDescription> rigidbody_descs;
-    std::vector<SkeletonDescription> skeleton_descs;
-    std::vector<MarkerSetDescription> markerset_descs;
-
-    std::vector<RigidBodyHistory> rbHistory;
+    static std::vector<RigidBodyDescription> rigidbody_descs;
+    static std::vector<SkeletonDescription> skeleton_descs;
+    static std::vector<MarkerSetDescription> markerset_descs;
 
     zmsg_t * handleMsg( sphactor_event_t *ev );
 
     //NatNet parse functions
-    void Unpack( char * pData );
     int SendCommand(char* szCOmmand);
     void HandleCommand(sPacket *PacketIn);
 
-    // ofxNatNet borrowed functions
+    void Unpack( char * pData );
     char* unpackRigidBodies(char* ptr, std::vector<RigidBody>& ref_rigidbodies);
     char* unpackMarkerSet(char* ptr, std::vector<Marker>& ref_markers);
     void sendRequestDescription();
-
-    //OSC Sending Functions
-    void addRigidbodies(zmsg_t *zmsg);
-    void addSkeletons(zmsg_t *zmsg);
-    void fixRanges( glm::vec3 *euler );
 
     //TODO: necessary?
     bool IPAddress_StringToAddr(char *szNameOrAddress, struct in_addr *Address);
     int GetLocalIPAddresses(unsigned long Addresses[], int nMax);
 
     NatNet() {
-
+        NatNetVersion = new int[]{0,0,0,0};
+        ServerVersion = new int[]{0,0,0,0};
     }
 };
 

--- a/Actors/NatNetDataTypes.h
+++ b/Actors/NatNetDataTypes.h
@@ -8,6 +8,7 @@
 #include "../ext/glm/glm/gtc/quaternion.hpp"
 
 // Custom data structs
+#define SMOOTHING                   2
 
 typedef glm::vec3 Marker;
 
@@ -81,6 +82,9 @@ public:
         currentDataPoint = 0;
         firstRun = true;
         framesInactive = 0;
+
+        velocities.resize(2 * SMOOTHING + 1);
+        angularVelocities.resize(2 * SMOOTHING + 1);
     }
 };
 
@@ -104,7 +108,7 @@ bool TimecodeStringify(unsigned int inTimecode, unsigned int inTimecodeSubframe,
 
 // Natnet settings
 
-#define SMOOTHING                   2
+
 
 #define MAX_NAMELENGTH              256
 
@@ -122,6 +126,12 @@ bool TimecodeStringify(unsigned int inTimecode, unsigned int inTimecodeSubframe,
 #define UNDEFINED                   999999.9999
 
 #define MAX_PACKETSIZE				100000	// max size of packet (actual packet size is dynamic)
+
+// This is needed to enhance portability for struct padding
+// a compiler will pad the struct at will to optimize it
+// for the compiled architecture
+// ref: https://forums.naturalpoint.com/viewtopic.php?f=59&t=13272
+#pragma pack(push,1)
 
 // sender
 typedef struct

--- a/Actors/NatNetDataTypes.h
+++ b/Actors/NatNetDataTypes.h
@@ -98,6 +98,10 @@ struct remove_dups
     bool operator()(const glm::vec3& t) { return glm::distance(v, t) <= dist; }
 };
 
+// time decode helper functions
+bool DecodeTimecode(unsigned int inTimecode, unsigned int inTimecodeSubframe, int* hour, int* minute, int* second, int* frame, int* subframe);
+bool TimecodeStringify(unsigned int inTimecode, unsigned int inTimecodeSubframe, char *Buffer, int BufferSize);
+
 // Natnet settings
 
 #define SMOOTHING                   2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,9 @@
 cmake_minimum_required(VERSION 3.1)
 project(gazebosc)
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-stack-check")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-stack-check")
+
 ##  Test availability of git and fetch submodules if needed
 #find_package(Git QUIET)
 #if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
@@ -35,6 +38,7 @@ if(NOT EXISTS "${PROJECT_SOURCE_DIR}/ext/czmq/CMakeLists.txt")
     message(FATAL_ERROR "The submodules in the ext directory are not available! GIT_SUBMODULE was turned off or failed. Please update submodules using \"git submodule update --init --recursive\" and try again.")
 endif()
 ## End getting the submodules
+
 
 set(CMAKE_CXX_STANDARD 14)
 set(DEP_IMGUI_VERSION "1.79" CACHE STRING "ImGui version to use")

--- a/actors.h
+++ b/actors.h
@@ -4,6 +4,7 @@
 #include "Actors/ClientActor.h"
 #include "Actors/CountActor.h"
 #include "Actors/NatNetActor.h"
+#include "Actors/NatNet2OSCActor.h"
 #include "Actors/OSCInputActor.h"
 #include "Actors/PulseActor.h"
 

--- a/stage.cpp
+++ b/stage.cpp
@@ -70,6 +70,7 @@ void RegisterActors() {
     sphactor_register<Count>( "Count" );
     sphactor_register( "Log", &LogActor, NULL, NULL );
     sphactor_register<NatNet>( "NatNet" );
+    sphactor_register<NatNet2OSC>( "NatNet2OSC" );
     sphactor_register<OSCInput>( "OSC Input" );
     sphactor_register<Pulse>( "Pulse" );
 


### PR DESCRIPTION
Implemented two separate actors, NatNet & NatNet2OSC. NatNet outputs a NatNet dgram packet wrapped in a zmsg. NatNet2OSC parses this into OSC in the same way that our NatNet2OSCBridge does.

Significant TODO's:
- Including and properly supporting a "NatNet" connection type to the front-end (because it's not an OSC message at all)
- Go through and optimise existing NatNet parsing, because it currently happens twice in similar functions. My current idea is to create a single static function (NatNet::Unpack), in which you can pass pointers to lists that should be updated with parsed Rigidbodies or descriptions etc.

Other small additions: LogActor now parses OSC messages. Currently uses printf.