### PR TITLE
Windows build instructions (still a workaround)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -52,7 +52,7 @@ build_script:
 #      ctest -C %Configuration% -V
 after_build:
   - cmd: cd "%GZB_BUILDDIR%\%Configuration%"
-  - cmd: copy "%INSTALL_PREFIX%\bin\*.*" .
+  - cmd: copy "%INSTALL_PREFIX%\bin\*.dll" .
   - cmd: 7z a -y -bd -mx=9 gazebosc.zip *.exe libzmq*.dll libczmq*.dll libsphactor*.dll
   - ps: Push-AppveyorArtifact "gazebosc.zip" -Filename "gazebosc-${env:Platform}-${env:Configuration}.zip"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -52,7 +52,7 @@ build_script:
 #      ctest -C %Configuration% -V
 after_build:
   - cmd: cd "%GZB_BUILDDIR%\%Configuration%"
-  - cmd: copy "%INSTALL_PREFIX%\bin\*.dll" .
+  - cmd: copy "%INSTALL_PREFIX%\bin\*.*" .
   - cmd: 7z a -y -bd -mx=9 gazebosc.zip *.exe libzmq*.dll libczmq*.dll libsphactor*.dll
   - ps: Push-AppveyorArtifact "gazebosc.zip" -Filename "gazebosc-${env:Platform}-${env:Configuration}.zip"
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,29 @@ cmake ..
 make
 ```
 
+#### Building on Windows
+
+* Install Visual Studio 2019: https://visualstudio.microsoft.com/downloads/
+When installing, make sure to include:
+- CMake
+- Git
+
+* Clone gazebosc repository
+```
+git clone http://github.com/hku-ect/gazebosc.git
+```
+
+* Run "x86 Native Tools Command Prompt for VS 2019" as Administrator
+* Navigate to gazebosc project root
+    Run "build_windows.bat"
+
+* Run Visual Studio, and select Open -> CMake
+    Navigate to gazebosc/CMakeListst.txt
+
+* Select "gazebosc.vcxproj" from debug targets
+
+You are now ready to debug as normal!
+
 #### Alternatively install dependencies from source
 
  * Clone & build libzmq, czmq, libsphactor & liblo

--- a/README.md
+++ b/README.md
@@ -60,24 +60,6 @@ cmake ..
 make
 ```
 
-#### Building on Windows
-
-* Install Visual Studio 2019: https://visualstudio.microsoft.com/downloads/ , make sure to include:
-	- CMake
-	- Git
-* Clone gazebosc repository
-```
-git clone http://github.com/hku-ect/gazebosc.git
-```
-* Run "x86 Native Tools Command Prompt for VS 2019" as Administrator
-	- Navigate to gazebosc project root
-    	- Run "build_windows.bat"
-* Run Visual Studio, and select Open -> CMake
-	- Navigate to gazebosc/CMakeListst.txt
-* Select "gazebosc.vcxproj" from debug targets
-
-You are now ready to debug as normal!
-
 #### Alternatively install dependencies from source
 
  * Clone & build libzmq, czmq, libsphactor & liblo
@@ -176,6 +158,24 @@ cd bin
 If you want to work on Gazebosc it's easiest to use QtCreator. Just load the CMakeLists.txt as a project in QtCreator and run from there.
 
 ---
+
+### Windows
+
+* Install Visual Studio 2019: https://visualstudio.microsoft.com/downloads/ , make sure to include:
+	- CMake
+	- Git
+* Clone gazebosc repository
+```
+git clone http://github.com/hku-ect/gazebosc.git
+```
+* Run "x86 Native Tools Command Prompt for VS 2019" as Administrator
+	- Navigate to gazebosc project root
+    	- Run "build_windows.bat"
+* Run Visual Studio, and select Open -> CMake
+	- Navigate to gazebosc/CMakeListst.txt
+* Select "gazebosc.vcxproj" from debug targets
+
+You are now ready to code/debug as normal!
 
 ## Adding new nodes
 

--- a/README.md
+++ b/README.md
@@ -62,23 +62,18 @@ make
 
 #### Building on Windows
 
-* Install Visual Studio 2019: https://visualstudio.microsoft.com/downloads/
-When installing, make sure to include:
-- CMake
-- Git
-
+* Install Visual Studio 2019: https://visualstudio.microsoft.com/downloads/ , make sure to include:
+	- CMake
+	- Git
 * Clone gazebosc repository
 ```
 git clone http://github.com/hku-ect/gazebosc.git
 ```
-
 * Run "x86 Native Tools Command Prompt for VS 2019" as Administrator
-* Navigate to gazebosc project root
-    Run "build_windows.bat"
-
+	- Navigate to gazebosc project root
+    	- Run "build_windows.bat"
 * Run Visual Studio, and select Open -> CMake
-    Navigate to gazebosc/CMakeListst.txt
-
+	- Navigate to gazebosc/CMakeListst.txt
 * Select "gazebosc.vcxproj" from debug targets
 
 You are now ready to debug as normal!

--- a/build_windows.bat
+++ b/build_windows.bat
@@ -1,0 +1,21 @@
+reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v UserAuthentication /t REG_DWORD /d 0 /f
+
+set PROJECT_ROOT=%cd%
+
+set INSTALL_PREFIX=%cd%/tmp/ci_build
+set LIBZMQ_SOURCEDIR=%cd%/remote/projects/libzmq
+set LIBZMQ_BUILDDIR=%LIBZMQ_SOURCEDIR%/build
+git clone --depth 1 --quiet https://github.com/zeromq/libzmq.git "%LIBZMQ_SOURCEDIR%"
+md "%LIBZMQ_BUILDDIR%"
+
+cd "%LIBZMQ_BUILDDIR%"
+cmake .. -DBUILD_STATIC=OFF -DBUILD_SHARED=ON -DZMQ_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX="%INSTALL_PREFIX%"
+cmake --build . --config Debug --target install
+
+set GZB_BUILDDIR="%PROJECT_ROOT%\build"
+cd %PROJECT_ROOT%
+git submodule update --init --recursive
+md "%GZB_BUILDDIR%"
+cd "%GZB_BUILDDIR%"
+cmake .. -DCMAKE_PREFIX_PATH="%cd%/tmp/ci_build" -DCMAKE_INSTALL_PREFIX="%INSTALL_PREFIX%"
+cmake --build . --config Debug --target install

--- a/build_windows.bat
+++ b/build_windows.bat
@@ -1,5 +1,3 @@
-reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v UserAuthentication /t REG_DWORD /d 0 /f
-
 set PROJECT_ROOT=%cd%
 
 set INSTALL_PREFIX=%cd%/tmp/ci_build


### PR DESCRIPTION
Added a batch script that executes a successful build (based on appveyor script)

Once this has run once, you can then use VS2019 as normal, if you open as CMake and select the correct project to run (gazebosc.vcxproj)