### PR TITLE
Print backtrace on abort or segv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ set(CMAKE_CXX_STANDARD 14)
 set(DEP_IMGUI_VERSION "1.79" CACHE STRING "ImGui version to use")
 set(DEP_IMNODES_DIR ".")
 
+option (WITH_UNWIND "Enable libunwind support" ON)
+
 ## Definitions for draft API's of submodules
 set(ENABLE_DRAFTS ON CACHE BOOL "enable zmq projects draft apis" FORCE)
 add_definitions(-DZMQ_BUILD_DRAFT_API=1)
@@ -75,6 +77,15 @@ if(Python3_FOUND)
 else()
     message (FATAL_ERROR "Cannot find Python3, make sure the development packages of Python are available on the system")
 endif()
+
+if (WITH_UNWIND)
+    find_package (Unwind)
+endif (WITH_UNWIND)
+if (Unwind_FOUND)
+    add_definitions(-DHAVE_LIBUNWIND)
+    set (HAVE_LIBUNWIND 1)
+    set (HAVE_UNWIND_H 1)
+endif (Unwind_FOUND)
 
 if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
     set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -131,6 +142,7 @@ add_executable(gazebosc
     ${ACTOR_HEADERS}
 )
 target_include_directories(gazebosc PUBLIC
+    ${Unwind_INCLUDE_DIRS}
     ${libzmq_INCLUDE_DIRS}
     ${Python3_INCLUDE_DIRS}
     ${CMAKE_CURRENT_BINARY_DIR}/imgui-${DEP_IMGUI_VERSION}
@@ -138,6 +150,11 @@ target_include_directories(gazebosc PUBLIC
     ${CMAKE_CURRENT_BINARY_DIR}/imgui-${DEP_IMGUI_VERSION}/examples/libs/gl3w
     ${DEP_IMNODES_DIR}
 )
+
+if (Unwind_FOUND)
+  target_link_libraries (gazebosc PUBLIC unwind::unwind)
+endif (Unwind_FOUND)
+
 if (APPLE)
     target_link_libraries(gazebosc PUBLIC
         SDL2-static

--- a/FindUnwind.cmake
+++ b/FindUnwind.cmake
@@ -1,0 +1,78 @@
+# - Try to find libunwind
+# Once done this will define
+#
+#  Unwind_FOUND - system has libunwind
+#  unwind::unwind - cmake target for libunwind
+
+include (FindPackageHandleStandardArgs)
+
+find_path (Unwind_INCLUDE_DIR NAMES unwind.h libunwind.h DOC "unwind include directory")
+find_library (Unwind_LIBRARY NAMES unwind DOC "unwind library")
+
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
+    set (Unwind_ARCH "arm")
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64")
+    set (Unwind_ARCH "aarch64")
+elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR
+        CMAKE_SYSTEM_PROCESSOR STREQUAL "amd64" OR
+        CMAKE_SYSTEM_PROCESSOR STREQUAL "corei7-64")
+    set (Unwind_ARCH "x86_64")
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^i.86$")
+    set (Unwind_ARCH "x86")
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^ppc64")
+    set (Unwind_ARCH "ppc64")
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^ppc")
+    set (Unwind_ARCH "ppc32")
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^mips")
+    set (Unwind_ARCH "mips")
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^hppa")
+    set (Unwind_ARCH "hppa")
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^ia64")
+    set (Unwind_ARCH "ia64")
+endif (CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
+
+find_library (Unwind_PLATFORM_LIBRARY NAMES "unwind-${Unwind_ARCH}"
+  DOC "unwind library platform")
+
+mark_as_advanced (Unwind_INCLUDE_DIR Unwind_LIBRARY Unwind_PLATFORM_LIBRARY)
+
+# Extract version information
+if (Unwind_LIBRARY)
+  set (_Unwind_VERSION_HEADER ${Unwind_INCLUDE_DIR}/libunwind-common.h)
+
+  if (EXISTS ${_Unwind_VERSION_HEADER})
+    FILE (READ ${_Unwind_VERSION_HEADER} _Unwind_VERSION_CONTENTS)
+
+    string (REGEX REPLACE ".*#define UNW_VERSION_MAJOR[ \t]+([0-9]+).*" "\\1"
+      Unwind_VERSION_MAJOR "${_Unwind_VERSION_CONTENTS}")
+    string (REGEX REPLACE ".*#define UNW_VERSION_MINOR[ \t]+([0-9]+).*" "\\1"
+      Unwind_VERSION_MINOR "${_Unwind_VERSION_CONTENTS}")
+    string (REGEX REPLACE ".*#define UNW_VERSION_EXTRA[ \t]+([0-9]+).*" "\\1"
+      Unwind_VERSION_PATCH "${_Unwind_VERSION_CONTENTS}")
+
+    set (Unwind_VERSION
+      ${Unwind_VERSION_MAJOR}.${Unwind_VERSION_MINOR}.${Unwind_VERSION_PATCH})
+    set (Unwind_VERSION_COMPONENTS 3)
+  endif (EXISTS ${_Unwind_VERSION_HEADER})
+endif (Unwind_LIBRARY)
+
+# handle the QUIETLY and REQUIRED arguments and set Unwind_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args (Unwind REQUIRED_VARS Unwind_INCLUDE_DIR
+  Unwind_LIBRARY Unwind_PLATFORM_LIBRARY VERSION_VAR Unwind_VERSION)
+
+if (Unwind_FOUND)
+  if (NOT TARGET unwind::unwind)
+    add_library (unwind::unwind INTERFACE IMPORTED)
+
+    set_property (TARGET unwind::unwind PROPERTY
+      INTERFACE_INCLUDE_DIRECTORIES ${Unwind_INCLUDE_DIR}
+    )
+    set_property (TARGET unwind::unwind PROPERTY
+      INTERFACE_LINK_LIBRARIES ${Unwind_LIBRARY} ${Unwind_PLATFORM_LIBRARY}
+    )
+    set_property (TARGET unwind::unwind PROPERTY
+      IMPORTED_CONFIGURATIONS RELEASE
+    )
+  endif (NOT TARGET unwind::unwind)
+endif (Unwind_FOUND)

--- a/FindUnwind.cmake
+++ b/FindUnwind.cmake
@@ -9,6 +9,10 @@ include (FindPackageHandleStandardArgs)
 find_path (Unwind_INCLUDE_DIR NAMES unwind.h libunwind.h DOC "unwind include directory")
 find_library (Unwind_LIBRARY NAMES unwind DOC "unwind library")
 
+if (APPLE AND Unwind_INCLUDE_DIR)
+  set (Unwind_LIBRARY "-framework System")
+endif (APPLE AND Unwind_INCLUDE_DIR)
+
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
     set (Unwind_ARCH "arm")
 elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64")
@@ -34,32 +38,12 @@ endif (CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
 find_library (Unwind_PLATFORM_LIBRARY NAMES "unwind-${Unwind_ARCH}"
   DOC "unwind library platform")
 
-mark_as_advanced (Unwind_INCLUDE_DIR Unwind_LIBRARY Unwind_PLATFORM_LIBRARY)
-
-# Extract version information
-if (Unwind_LIBRARY)
-  set (_Unwind_VERSION_HEADER ${Unwind_INCLUDE_DIR}/libunwind-common.h)
-
-  if (EXISTS ${_Unwind_VERSION_HEADER})
-    FILE (READ ${_Unwind_VERSION_HEADER} _Unwind_VERSION_CONTENTS)
-
-    string (REGEX REPLACE ".*#define UNW_VERSION_MAJOR[ \t]+([0-9]+).*" "\\1"
-      Unwind_VERSION_MAJOR "${_Unwind_VERSION_CONTENTS}")
-    string (REGEX REPLACE ".*#define UNW_VERSION_MINOR[ \t]+([0-9]+).*" "\\1"
-      Unwind_VERSION_MINOR "${_Unwind_VERSION_CONTENTS}")
-    string (REGEX REPLACE ".*#define UNW_VERSION_EXTRA[ \t]+([0-9]+).*" "\\1"
-      Unwind_VERSION_PATCH "${_Unwind_VERSION_CONTENTS}")
-
-    set (Unwind_VERSION
-      ${Unwind_VERSION_MAJOR}.${Unwind_VERSION_MINOR}.${Unwind_VERSION_PATCH})
-    set (Unwind_VERSION_COMPONENTS 3)
-  endif (EXISTS ${_Unwind_VERSION_HEADER})
-endif (Unwind_LIBRARY)
+mark_as_advanced (Unwind_INCLUDE_DIR Unwind_LIBRARY)
 
 # handle the QUIETLY and REQUIRED arguments and set Unwind_FOUND to TRUE
 # if all listed variables are TRUE
 find_package_handle_standard_args (Unwind REQUIRED_VARS Unwind_INCLUDE_DIR
-  Unwind_LIBRARY Unwind_PLATFORM_LIBRARY VERSION_VAR Unwind_VERSION)
+  Unwind_LIBRARY)
 
 if (Unwind_FOUND)
   if (NOT TARGET unwind::unwind)
@@ -69,7 +53,7 @@ if (Unwind_FOUND)
       INTERFACE_INCLUDE_DIRECTORIES ${Unwind_INCLUDE_DIR}
     )
     set_property (TARGET unwind::unwind PROPERTY
-      INTERFACE_LINK_LIBRARIES ${Unwind_LIBRARY} ${Unwind_PLATFORM_LIBRARY}
+      INTERFACE_LINK_LIBRARIES ${Unwind_LIBRARY}
     )
     set_property (TARGET unwind::unwind PROPERTY
       IMPORTED_CONFIGURATIONS RELEASE

--- a/main.cpp
+++ b/main.cpp
@@ -147,8 +147,13 @@ void print_backtrace (int sig) {}
 // Main code
 int main(int argc, char** argv)
 {
-    signal(SIGSEGV, print_backtrace);
-    signal(SIGABRT, print_backtrace);
+    signal(SIGSEGV, print_backtrace); // Invalid memory reference
+    signal(SIGABRT, print_backtrace); // Abort signal from abort(3)
+    signal(SIGBUS,  print_backtrace); // Bus error (bad memory access)
+    signal(SIGFPE,  print_backtrace); // Floating-point exception
+    signal(SIGSYS,  print_backtrace); // Bad system call (SVr4);
+    signal(SIGXCPU, print_backtrace); // CPU time limit exceeded (4.2BSD)
+    //signal(SIGFSZ,  print_backtrace); // File size limit exceeded (4.2BSD)
     RegisterActors();
 
     // Argument capture
@@ -226,6 +231,7 @@ int main(int argc, char** argv)
 
         zsys_info("VERSION: %s", glsl_version);
         io = ImGUIInit(window, &gl_context, glsl_version);
+
         // Blocking UI loop
         UILoop(window, io);
 


### PR DESCRIPTION
Only tested on Linux for now but it should be doable on Windows and OSX as well.
Can really help tracing crashes!!!

Perhaps add a coredump as well?
https://code.google.com/archive/p/google-coredumper/