### PR TITLE
Fixes for windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -55,14 +55,14 @@ before_build:
       set GZB_BUILDDIR=%APPVEYOR_BUILD_FOLDER%\build
       set PY_INSTALLDIR=%GZB_BUILDDIR%\bin\%Configuration%\python
       set PY_EXE=python.exe
-      set PY_LAYOUTOPTS=--preset-embed --include-dev --include-pip
+      set PY_LAYOUTOPTS=--include-dev --include-pip
       md "%PY_INSTALLDIR%"
       cd "%PYTHON_SOURCEDIR%"\PCbuild
       build.bat -p x64      
       IF "%Configuration%" == "Debug" build.bat -p x64 -c Debug
       cd amd64
       .\%PY_EXE% ../../PC/layout -b . -s %PYTHON_SOURCEDIR% %PY_LAYOUTOPTS% --copy %PY_INSTALLDIR%
-      IF "%Configuration%" == "Debug" set PY_LAYOUTOPTS=-d --preset-embed --include-dev --include-pip
+      IF "%Configuration%" == "Debug" set PY_LAYOUTOPTS=-d --include-dev --include-pip --include-symbols
       IF "%Configuration%" == "Debug" .\%PY_EXE% ../../PC/layout -b . -s %PYTHON_SOURCEDIR% %PY_LAYOUTOPTS% --copy %PY_INSTALLDIR%
 
 build_script:
@@ -76,6 +76,7 @@ build_script:
 after_build:
   - cmd: cd "%GZB_BUILDDIR%\bin\%Configuration%"
   - cmd: copy "%INSTALL_PREFIX%\bin\*.dll" .
+  - cmd: copy python\*.dll" .
   - cmd: |
       echo %CSCRT% > tmp64
       certutil -decode tmp64 tmpcrt & exit 0

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,12 +11,12 @@ environment:
   CSRTPW:
     secure: RGIQP5FFFYx/tICrrkoiJzSXMqDz/R1H+WAAKZ0bo6E=
   matrix:
-    - platform: Win32
-      configuration: Debug
-      PY_DIR: C:/Python38
-    - platform: Win32
-      configuration: Release
-      PY_DIR: C:/Python38
+#    - platform: Win32
+#      configuration: Debug
+#      PY_DIR: C:/Python38
+#    - platform: Win32
+#      configuration: Release
+#      PY_DIR: C:/Python38
     - platform: x64
       configuration: Debug
       PY_DIR: C:/Python38-x64
@@ -48,29 +48,29 @@ install:
 before_build:
   - cmd: |
       cd "%LIBZMQ_BUILDDIR%"
-      cmake .. -DBUILD_STATIC=OFF -DBUILD_SHARED=ON -DZMQ_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX="%INSTALL_PREFIX%"
+      cmake .. -Ax64 -DBUILD_STATIC=OFF -DBUILD_SHARED=ON -DZMQ_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX="%INSTALL_PREFIX%"
       cmake --build . --config %Configuration% --target install
   - cmd: |
       python --version
       set GZB_BUILDDIR=%APPVEYOR_BUILD_FOLDER%\build
       set PY_INSTALLDIR=%GZB_BUILDDIR%\bin\%Configuration%
       set PY_EXE=python.exe
-      set PY_LAYOUTOPTS=--preset-default
+      set PY_LAYOUTOPTS=--preset-embed --include-dev --include-pip
       md "%PY_INSTALLDIR%"
       cd "%PYTHON_SOURCEDIR%"\PCbuild
       build.bat -p x64      
       IF "%Configuration%" == "Debug" build.bat -p x64 -c Debug
       cd amd64
       .\%PY_EXE% ../../PC/layout -b . -s %PYTHON_SOURCEDIR% %PY_LAYOUTOPTS% --preset-default --copy %PY_INSTALLDIR%
-      IF "%Configuration%" == "Debug" set PY_LAYOUTOPTS=-d --preset-default
-      IF "%Configuration%" == "Debug" .\%PY_EXE% ../../PC/layout -b . -s %PYTHON_SOURCEDIR% %PY_LAYOUTOPTS% --preset-default --copy %PY_INSTALLDIR%
+      IF "%Configuration%" == "Debug" set PY_LAYOUTOPTS=-d --preset-embed --include-dev --include-pip
+      IF "%Configuration%" == "Debug" .\%PY_EXE% ../../PC/layout -b . -s %PYTHON_SOURCEDIR% %PY_LAYOUTOPTS% --copy %PY_INSTALLDIR%
 
 build_script:
   - cmd: |
       cd "%APPVEYOR_BUILD_FOLDER%"
       git submodule update --init --recursive
       cd "%GZB_BUILDDIR%"
-      cmake .. -DCMAKE_PREFIX_PATH="C:\tmp\ci_build" -DPython3_ROOT_DIR="%PY_INSTALLDIR%"
+      cmake .. -Ax64 -DCMAKE_PREFIX_PATH="%INSTALL_PREFIX%" -DPython3_ROOT_DIR="%PY_INSTALLDIR%"
   -    cmake --build . --config %Configuration% --target install
 #      ctest -C %Configuration% -V
 after_build:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -53,7 +53,7 @@ before_build:
   - cmd: |
       python --version
       set GZB_BUILDDIR=%APPVEYOR_BUILD_FOLDER%\build
-      set PY_INSTALLDIR=%GZB_BUILDDIR%\bin\%Configuration%
+      set PY_INSTALLDIR=%GZB_BUILDDIR%\bin\%Configuration%\python
       set PY_EXE=python.exe
       set PY_LAYOUTOPTS=--preset-embed --include-dev --include-pip
       md "%PY_INSTALLDIR%"
@@ -61,7 +61,7 @@ before_build:
       build.bat -p x64      
       IF "%Configuration%" == "Debug" build.bat -p x64 -c Debug
       cd amd64
-      .\%PY_EXE% ../../PC/layout -b . -s %PYTHON_SOURCEDIR% %PY_LAYOUTOPTS% --preset-default --copy %PY_INSTALLDIR%
+      .\%PY_EXE% ../../PC/layout -b . -s %PYTHON_SOURCEDIR% %PY_LAYOUTOPTS% --copy %PY_INSTALLDIR%
       IF "%Configuration%" == "Debug" set PY_LAYOUTOPTS=-d --preset-embed --include-dev --include-pip
       IF "%Configuration%" == "Debug" .\%PY_EXE% ../../PC/layout -b . -s %PYTHON_SOURCEDIR% %PY_LAYOUTOPTS% --copy %PY_INSTALLDIR%
 

--- a/Actors/PulseActor.cpp
+++ b/Actors/PulseActor.cpp
@@ -6,7 +6,7 @@ const char * pulseCapabilities =
                                 "    data\n"
                                 "        name = \"timeout\"\n"
                                 "        type = \"int\"\n"
-                                "        value = \"60\"\n"
+                                "        value = \"1000\"\n"
                                 "        min = \"1\"\n"
                                 "        max = \"10000\"\n"
                                 "        step = \"1\"\n"

--- a/Actors/pythonactor.c
+++ b/Actors/pythonactor.c
@@ -62,6 +62,14 @@ s_py_zosc(PyObject *pAddress, PyObject *pData)
             long v = PyLong_AsLong(item);
             zosc_append(ret, "h", v);
         }
+        else if (PyUnicode_Check(item))
+        {
+            PyObject* ascii = PyUnicode_AsASCIIString(item);
+            assert(ascii);
+            char* s = PyBytes_AsString(ascii);
+            zosc_append(ret, "s", s);
+            Py_DECREF(ascii);
+        }
         else
             zsys_warning("unsupported python type");
     }

--- a/Actors/pythonactor.c
+++ b/Actors/pythonactor.c
@@ -92,11 +92,11 @@ int python_init()
         swprintf(pypath, PATH_MAX, L"%hs/python", path);
 #elif defined(__WINDOWS__)
         wchar_t path[PATH_MAX];
-        GetModuleFileName(NULL, path, PATH_MAX);
+        GetModuleFileNameW(NULL, path, PATH_MAX);
         // remove program name by finding the last delimiter
         wchar_t *s = wcsrchr(path, L'\\');
         if (s) *s = 0;
-        swprintf(pypath, PATH_MAX, L"%hs\\python", path);
+        swprintf(pypath, PATH_MAX, L"%ls\\python", path);
 #else   // linux, we could check for __UTYPE_LINUX
         size_t pathsize;
         char path[PATH_MAX];

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,12 +67,13 @@ if (NOT libzmq_FOUND)
 endif()
 
 # Find Python3
+set(Python3_USE_STATIC_LIBS FALSE)
 if(Python3_ROOT_DIR)                        # Usually specified on command line to find python explicitly
     set(Python3_FIND_STRATEGY "LOCATION")
 endif(Python3_ROOT_DIR)
 find_package (Python3 REQUIRED COMPONENTS Development)
 if(Python3_FOUND)
-    message ("python3 found")
+    message ("python3 found libs: ${Python3_LIBRARIES} incl: ${Python3_INCLUDE_DIRS}")
     add_definitions(-DPYTHON3_FOUND)
 else()
     message (FATAL_ERROR "Cannot find Python3, make sure the development packages of Python are available on the system")
@@ -152,6 +153,8 @@ if (Unwind_FOUND)
   target_link_libraries (gazebosc PUBLIC unwind::unwind)
 endif (Unwind_FOUND)
 
+
+target_link_options(gazebosc PUBLIC ${Python3_LINK_OPTIONS})
 ### PLATFORM SPECIFICS
 if (APPLE)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-stack-check")
@@ -161,7 +164,7 @@ if (APPLE)
     target_link_libraries(gazebosc PUBLIC
         SDL2-static
         sphactor-static
-        Python3::Python
+        ${Python3_LIBRARIES}
         -ldl "-framework OpenGL" "-framework CoreFoundation" "-framework CoreMidi" "-framework CoreAudio")
     SET_TARGET_PROPERTIES(gazebosc PROPERTIES
         MACOSX_BUNDLE TRUE 
@@ -206,13 +209,13 @@ elseif (WIN32)
         czmq-static
         sphactor-static
         ${libzmq_LIBRARIES}
-        Python3::Python
+        ${Python3_LIBRARIES}
         opengl32.lib)
 else()
     target_link_libraries(gazebosc PUBLIC
         SDL2-static
         sphactor-static
-        Python3::Python
+        ${Python3_LIBRARIES}
         -lasound -ldl -lGL -lGLEW)
     target_compile_options(gazebosc PUBLIC -D__LINUX_ALSA__ )
 endif()

--- a/stage.cpp
+++ b/stage.cpp
@@ -82,7 +82,8 @@ void RegisterActors() {
     sphactor_register<Pulse>( "Pulse" );
     sphactor_register<ModPlayerActor>( "ModPlayer" );
 #ifdef PYTHON3_FOUND
-    assert( python_init() == 0);
+    int rc = python_init();
+    assert( rc == 0);
     sphactor_register("Python", pythonactor_handler, pythonactor_new_helper, NULL); // https://stackoverflow.com/questions/65957511/typedef-for-a-registering-a-constructor-function-in-c
 #endif
     //enforcable maximum actor counts


### PR DESCRIPTION
I'm not sure but I had crashed on test build with the python interpreter being null on PyGIL_Ensure.... calls. That's weird. I reckon this could be due to the fact that python is linked statically but the call refers to the dll.