### PR TITLE
Simple setup to select interfaces on NatNet actor

### DIFF
--- a/ActorContainer.h
+++ b/ActorContainer.h
@@ -440,8 +440,10 @@ struct ActorContainer {
 
         ImGui::SetNextItemWidth(100);
         if ( ImGui::InputInt( name, &value, step, 100,ImGuiInputTextFlags_EnterReturnsTrue ) ) {
-            if ( min != max ) {
-                if ( value < min ) value = min;
+            if ( zmin ) {
+                if (value < min) value = min;
+            }
+            if ( zmax ) {
                 if ( value > max ) value = max;
             }
 

--- a/Actors/NatNetActor.cpp
+++ b/Actors/NatNetActor.cpp
@@ -2,7 +2,6 @@
 #include <string>
 #include <algorithm>
 #include <time.h>
-#include <stdlib.h>
 
 //static variable definitions
 int* NatNet::NatNetVersion = new int[4]{0,0,0,0};

--- a/Actors/NatNetActor.h
+++ b/Actors/NatNetActor.h
@@ -20,6 +20,10 @@ struct NatNet {
     // ServerAddress
     std::string host = "";
 
+    std::vector<std::string> ifNames;
+    std::vector<std::string> ifAddresses;
+    std::string activeInterface = "";
+
     // NatNet vars
     static int* NatNetVersion;
     static int* ServerVersion;


### PR DESCRIPTION
Currently just a list of the interfaces as part of the report. Should become a drop-down in future, but at least this allows us to influence where we want the data to come from.

Also includes a minor fix in the min/max limiter, since it currently assumed that when they are they same, there is no min/max check necessary (which is false if there is a list of 1 items).