### PR TITLE
Updates Natnet Unpack to 3.1

### DIFF
--- a/Actors/NatNetActor.cpp
+++ b/Actors/NatNetActor.cpp
@@ -690,7 +690,7 @@ void NatNet::Unpack( char ** pData ) {
             {
                 // ID
                 int ID = 0; memcpy(&ID, ptr, 4); ptr += 4;
-                printf("Device : %d\n", ID);
+                //printf("Device : %d\n", ID);
 
                 // Channel Count
                 int nChannels = 0; memcpy(&nChannels, ptr, 4); ptr += 4;
@@ -698,14 +698,14 @@ void NatNet::Unpack( char ** pData ) {
                 // Channel Data
                 for (int i = 0; i < nChannels; i++)
                 {
-                    printf(" Channel %d : ", i);
+                    //printf(" Channel %d : ", i);
                     int nFrames = 0; memcpy(&nFrames, ptr, 4); ptr += 4;
                     for (int j = 0; j < nFrames; j++)
                     {
                         float val = 0.0f;  memcpy(&val, ptr, 4); ptr += 4;
-                        printf("%3.2f   ", val);
+                        //printf("%3.2f   ", val);
                     }
-                    printf("\n");
+                    //printf("\n");
                 }
             }
         }
@@ -743,15 +743,15 @@ void NatNet::Unpack( char ** pData ) {
         {
             uint64_t cameraMidExposureTimestamp = 0;
             memcpy(&cameraMidExposureTimestamp, ptr, 8); ptr += 8;
-            printf("Mid-exposure timestamp : %" PRIu64"\n", cameraMidExposureTimestamp);
+            //printf("Mid-exposure timestamp : %" PRIu64"\n", cameraMidExposureTimestamp);
 
             uint64_t cameraDataReceivedTimestamp = 0;
             memcpy(&cameraDataReceivedTimestamp, ptr, 8); ptr += 8;
-            printf("Camera data received timestamp : %" PRIu64"\n", cameraDataReceivedTimestamp);
+            //printf("Camera data received timestamp : %" PRIu64"\n", cameraDataReceivedTimestamp);
 
             uint64_t transmitTimestamp = 0;
             memcpy(&transmitTimestamp, ptr, 8); ptr += 8;
-            printf("Transmit timestamp : %" PRIu64"\n", transmitTimestamp);
+            //printf("Transmit timestamp : %" PRIu64"\n", transmitTimestamp);
         }
 
         // frame params
@@ -911,12 +911,12 @@ void NatNet::Unpack( char ** pData ) {
                         float* markerPosition = markerPositions + markerIdx * 3;
                         const int markerRequiredLabel = markerRequiredLabels[markerIdx];
 
-                        printf("\tMarker #%d:\n", markerIdx);
-                        printf("\t\tPosition: %.2f, %.2f, %.2f\n", markerPosition[0], markerPosition[1], markerPosition[2]);
+                        //printf("\tMarker #%d:\n", markerIdx);
+                        //printf("\t\tPosition: %.2f, %.2f, %.2f\n", markerPosition[0], markerPosition[1], markerPosition[2]);
 
                         if (markerRequiredLabel != 0)
                         {
-                            printf("\t\tRequired active label: %d\n", markerRequiredLabel);
+                            //printf("\t\tRequired active label: %d\n", markerRequiredLabel);
                         }
                     }
 

--- a/Actors/NatNetActor.cpp
+++ b/Actors/NatNetActor.cpp
@@ -448,13 +448,8 @@ char* NatNet::unpackRigidBodies(char* ptr, std::vector<RigidBody>& ref_rigidbodi
         RB.position = pp;
         RB.rotation = q;
 
-        //TODO: Matrix, only used for scale previously
-        //pp = transform.preMult(pp);
-        //
-        //ofMatrix4x4 mat;
-        //mat.setTranslation(pp);
-        //mat.setRotate(q * rot);
-        //RB.matrix = mat;
+        //TODO: These associated markers are no longer part of the 3.1 SDK example
+        //          -> Check if we can/need to remove this...
 
         // associated marker positions
         int nRigidMarkers = 0;
@@ -492,6 +487,8 @@ char* NatNet::unpackRigidBodies(char* ptr, std::vector<RigidBody>& ref_rigidbodi
         }
 
         if (markerData) free(markerData);
+
+        // TODO: 3.1 SDK Contains everything after this again
 
         if (major >= 2)
         {
@@ -627,6 +624,21 @@ void NatNet::Unpack( char ** pData ) {
                     bool bOccluded = params & 0x01;     // marker was not visible (occluded) in this frame
                     bool bPCSolved = params & 0x02;     // position provided by point cloud solve
                     bool bModelSolved = params & 0x04;  // position provided by model solve
+                    // 3.0 additions
+                    if ((major >= 3) || (major == 0))
+                    {
+                        bool bHasModel = (params & 0x08) != 0;     // marker has an associated asset in the data stream
+                        bool bUnlabeled = (params & 0x10) != 0;    // marker is 'unlabeled', but has a point cloud ID
+                        bool bActiveMarker = (params & 0x20) != 0; // marker is an actively labeled LED marker
+                    }
+                }
+
+                // NatNet version 3.0 and later
+                float residual = 0.0f;
+                if ((major >= 3) || (major == 0))
+                {
+                    // Marker residual
+                    memcpy(&residual, ptr, 4); ptr += 4;
                 }
 
                 //zsys_info("ID  : %d\n", ID);
@@ -669,10 +681,42 @@ void NatNet::Unpack( char ** pData ) {
             }
         }
 
-        // latency
-        float latency = 0.0f; memcpy(&latency, ptr, 4);	ptr += 4;
-        //zsys_info("latency : %3.3f\n", latency);
-        this->latency = latency;
+        // TODO: Device data (NatNet version 3.0 and later)
+        if (((major == 2) && (minor >= 11)) || (major > 2))
+        {
+            int nDevices;
+            memcpy(&nDevices, ptr, 4); ptr += 4;
+            for (int iDevice = 0; iDevice < nDevices; iDevice++)
+            {
+                // ID
+                int ID = 0; memcpy(&ID, ptr, 4); ptr += 4;
+                printf("Device : %d\n", ID);
+
+                // Channel Count
+                int nChannels = 0; memcpy(&nChannels, ptr, 4); ptr += 4;
+
+                // Channel Data
+                for (int i = 0; i < nChannels; i++)
+                {
+                    printf(" Channel %d : ", i);
+                    int nFrames = 0; memcpy(&nFrames, ptr, 4); ptr += 4;
+                    for (int j = 0; j < nFrames; j++)
+                    {
+                        float val = 0.0f;  memcpy(&val, ptr, 4); ptr += 4;
+                        printf("%3.2f   ", val);
+                    }
+                    printf("\n");
+                }
+            }
+        }
+
+        // latency, removed in 3.0
+        if (major < 3)
+        {
+            float latency = 0.0f; memcpy(&latency, ptr, 4);	ptr += 4;
+            //zsys_info("latency : %3.3f\n", latency);
+            this->latency = latency;
+        }
 
         // timecode
         unsigned int timecode = 0; 	memcpy(&timecode, ptr, 4);	ptr += 4;
@@ -692,6 +736,22 @@ void NatNet::Unpack( char ** pData ) {
             float fTemp = 0.0f;
             memcpy(&fTemp, ptr, 4); ptr += 4;
             timestamp = (double)fTemp;
+        }
+
+        // high res timestamps (version 3.0 and later)
+        if ((major >= 3) || (major == 0))
+        {
+            uint64_t cameraMidExposureTimestamp = 0;
+            memcpy(&cameraMidExposureTimestamp, ptr, 8); ptr += 8;
+            printf("Mid-exposure timestamp : %" PRIu64"\n", cameraMidExposureTimestamp);
+
+            uint64_t cameraDataReceivedTimestamp = 0;
+            memcpy(&cameraDataReceivedTimestamp, ptr, 8); ptr += 8;
+            printf("Camera data received timestamp : %" PRIu64"\n", cameraDataReceivedTimestamp);
+
+            uint64_t transmitTimestamp = 0;
+            memcpy(&transmitTimestamp, ptr, 8); ptr += 8;
+            printf("Transmit timestamp : %" PRIu64"\n", transmitTimestamp);
         }
 
         // frame params
@@ -828,6 +888,41 @@ void NatNet::Unpack( char ** pData ) {
                 description.offset[0] = xoffset;
                 description.offset[1] = yoffset;
                 description.offset[2] = zoffset;
+
+                // TODO: Per-marker data (NatNet 3.0 and later)
+                if (major >= 3)
+                {
+                    int nMarkers = 0; memcpy(&nMarkers, ptr, 4); ptr += 4;
+
+                    // Marker positions
+                    nBytes = nMarkers * 3 * sizeof(float);
+                    float* markerPositions = (float*)malloc(nBytes);
+                    memcpy(markerPositions, ptr, nBytes);
+                    ptr += nBytes;
+
+                    // Marker required active labels
+                    nBytes = nMarkers * sizeof(int);
+                    int* markerRequiredLabels = (int*)malloc(nBytes);
+                    memcpy(markerRequiredLabels, ptr, nBytes);
+                    ptr += nBytes;
+
+                    for (int markerIdx = 0; markerIdx < nMarkers; ++markerIdx)
+                    {
+                        float* markerPosition = markerPositions + markerIdx * 3;
+                        const int markerRequiredLabel = markerRequiredLabels[markerIdx];
+
+                        printf("\tMarker #%d:\n", markerIdx);
+                        printf("\t\tPosition: %.2f, %.2f, %.2f\n", markerPosition[0], markerPosition[1], markerPosition[2]);
+
+                        if (markerRequiredLabel != 0)
+                        {
+                            printf("\t\tRequired active label: %d\n", markerRequiredLabel);
+                        }
+                    }
+
+                    free(markerPositions);
+                    free(markerRequiredLabels);
+                }
 
                 tmp_rigidbody_descs.push_back(description);
             }


### PR DESCRIPTION
Don't merge until we've tested it with a newer version.

This updates the _Unpack()_ functions on our NatNet actors in line with the 3.1 NatNet SDK sample.

**TODO**
- Test if it works with our current motive version
- Test if it works with the newer motive version
  - There's a whole extra part with associated marker sets, marked with a remove //TODO in code
  - Check if there's any of the non-packet functionality that needs updating
- Implement missing additions of newer motive versions (devices, led markers, etc.)