### PR TITLE
Added copy action for OpenVR DLL on WIN32 target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,14 +318,12 @@ if(APPLE)
             $<TARGET_FILE_DIR:${PROJECT_NAME}>/../Resources/misc)
 else()
     install(TARGETS gazebosc DESTINATION bin)
-    if (WIN32)
-        if (WITH_OPENVR)
-            add_custom_command(TARGET gazebosc POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy
-                    "${PROJECT_SOURCE_DIR}/ext/openvr/bin/win64/openvr_api.dll"
-                    $<TARGET_FILE_DIR:${PROJECT_NAME}>)
-            message("COPY OPENVER")
-        endif()
+    if (WIN32 AND WITH_OPENVR)
+        add_custom_command(TARGET gazebosc POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy
+                "${PROJECT_SOURCE_DIR}/ext/openvr/bin/win${ARCH}/openvr_api.dll"
+                $<TARGET_FILE_DIR:${PROJECT_NAME}>)
+        message("COPY OPENVER")
     endif()
     add_custom_command(
         TARGET gazebosc POST_BUILD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,11 +319,13 @@ if(APPLE)
 else()
     install(TARGETS gazebosc DESTINATION bin)
     if (WIN32)
-        add_custom_command(TARGET gazebosc POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy
-                "${PROJECT_SOURCE_DIR}/ext/openvr/bin/win64/openvr_api.dll"
-                $<TARGET_FILE_DIR:${PROJECT_NAME}>)
-        message("COPY OPENVER")
+        if (WITH_OPENVR)
+            add_custom_command(TARGET gazebosc POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy
+                    "${PROJECT_SOURCE_DIR}/ext/openvr/bin/win64/openvr_api.dll"
+                    $<TARGET_FILE_DIR:${PROJECT_NAME}>)
+            message("COPY OPENVER")
+        endif()
     endif()
     add_custom_command(
         TARGET gazebosc POST_BUILD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,6 +318,13 @@ if(APPLE)
             $<TARGET_FILE_DIR:${PROJECT_NAME}>/../Resources/misc)
 else()
     install(TARGETS gazebosc DESTINATION bin)
+    if (WIN32)
+        add_custom_command(TARGET gazebosc POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy
+                "${PROJECT_SOURCE_DIR}/ext/openvr/bin/win64/openvr_api.dll"
+                $<TARGET_FILE_DIR:${PROJECT_NAME}>)
+        message("COPY OPENVER")
+    endif()
     add_custom_command(
         TARGET gazebosc POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory


### PR DESCRIPTION
Currently hardcodes to the win64 folder, but I'm not sure we'll ever need to distinguish between it or the win32 version...