### PR TITLE
add a row delay capability

### DIFF
--- a/Actors/ModPlayerActor.h
+++ b/Actors/ModPlayerActor.h
@@ -36,6 +36,7 @@ struct ModPlayerActor : Sphactor
     muchar orig_patterntable[128];
     int start_pos;
     int end_pos;
+    int rowdelay;
     unsigned char * modfile;
     tracker_buffer_state trackbuf_state1;
     SDL_AudioDeviceID audiodev = -1;


### PR DESCRIPTION
to manually sync events as the modplayer is often too early as it renders audio before sending it out so osc events are too early too usually