### PR TITLE
Made rtmidi lib static, fixed crash

### DIFF
--- a/Actors/Midi2OSCActor.cpp
+++ b/Actors/Midi2OSCActor.cpp
@@ -59,7 +59,8 @@ zmsg_t * Midi2OSC::handleInit( sphactor_event_t *ev )
         }
     }
 
-    midiin->openPort(0);
+    if ( nPorts > 0 )
+        midiin->openPort(0);
 
     return Sphactor::handleInit(ev);
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,8 @@ add_subdirectory("ext/libsphactor" EXCLUDE_FROM_ALL)
 add_subdirectory("ext/SDL-mirror" EXCLUDE_FROM_ALL)
 add_subdirectory("ext/glm" EXCLUDE_FROM_ALL)
 set( RTMIDI_TARGETNAME_UNINSTALL "rtmidi_uninstall" CACHE STRING "Name of 'uninstall' build target")
+set( RTMIDI_BUILD_SHARED_LIBS "")
+set( RTMIDI_BUILD_STATIC_LIBS "#" )
 add_subdirectory("ext/rtmidi" EXCLUDE_FROM_ALL)
 
 # External system libraries through find_package


### PR DESCRIPTION
Should run normally now without the inclusion of DLL/dylib.

Crash was due to opening midi ports when none were found.