### PR TITLE
Node Connection Updates

### DIFF
--- a/ActorContainer.h
+++ b/ActorContainer.h
@@ -93,10 +93,13 @@ struct ActorContainer {
 
                 char* typeStr = zconfig_value(type);
                 if ( streq(typeStr, "OSC")) {
-                    input_slots.push_back({ "OSC", ActorSlotOSC });
+                    input_slots.push_back({ "OSC", ActorSlotOSC  });
                 }
                 else if ( streq(typeStr, "NatNet")) {
                     input_slots.push_back({ "NatNet", ActorSlotNatNet });
+                }
+                else if ( streq(typeStr, "Any")) {
+                    input_slots.push_back({ "Any", ActorSlotAny });
                 }
                 else {
                     zsys_error("Unsupported input type: %s", typeStr);
@@ -116,6 +119,9 @@ struct ActorContainer {
                 }
                 else if ( streq(typeStr, "NatNet")) {
                     output_slots.push_back({ "NatNet", ActorSlotNatNet });
+                }
+                else if ( streq(typeStr, "Any")) {
+                    output_slots.push_back({ "Any", ActorSlotAny });
                 }
                 else {
                     zsys_error("Unsupported output type: %s", typeStr);

--- a/ActorContainer.h
+++ b/ActorContainer.h
@@ -93,13 +93,13 @@ struct ActorContainer {
 
                 char* typeStr = zconfig_value(type);
                 if ( streq(typeStr, "OSC")) {
-                    input_slots.push_back({ "OSC", ActorSlotOSC  });
+                    input_slots.push_back({ "OSC", ActorSlotOSC, false });
                 }
                 else if ( streq(typeStr, "NatNet")) {
-                    input_slots.push_back({ "NatNet", ActorSlotNatNet });
+                    input_slots.push_back({ "NatNet", ActorSlotNatNet, false });
                 }
                 else if ( streq(typeStr, "Any")) {
-                    input_slots.push_back({ "Any", ActorSlotAny });
+                    input_slots.push_back({ "Any", ActorSlotAny, true });
                 }
                 else {
                     zsys_error("Unsupported input type: %s", typeStr);
@@ -115,13 +115,13 @@ struct ActorContainer {
 
                 char* typeStr = zconfig_value(type);
                 if ( streq(typeStr, "OSC")) {
-                    output_slots.push_back({ "OSC", ActorSlotOSC });
+                    output_slots.push_back({ "OSC", ActorSlotOSC, false });
                 }
                 else if ( streq(typeStr, "NatNet")) {
-                    output_slots.push_back({ "NatNet", ActorSlotNatNet });
+                    output_slots.push_back({ "NatNet", ActorSlotNatNet, false });
                 }
                 else if ( streq(typeStr, "Any")) {
-                    output_slots.push_back({ "Any", ActorSlotAny });
+                    output_slots.push_back({ "Any", ActorSlotAny, true });
                 }
                 else {
                     zsys_error("Unsupported output type: %s", typeStr);

--- a/Actors/OSCRecordActor.cpp
+++ b/Actors/OSCRecordActor.cpp
@@ -21,12 +21,10 @@ const char * OSCRecord::capabilities =
         "        name = \"Stop\"\n"
         "        type = \"trigger\"\n"
         "        api_call = \"STOP_RECORD\"\n"
-        "        value = \"\"\n"
         "    data\n"
         "        name = \"Play\"\n"
         "        type = \"trigger\"\n"
         "        api_call = \"PLAY_RECORDING\"\n"
-        "        value = \"\"\n"
         "    data\n"
         "        name = \"loop\"\n"
         "        type = \"bool\"\n"
@@ -41,10 +39,10 @@ const char * OSCRecord::capabilities =
         "        api_value = \"s\"\n"
         "inputs\n"
         "    input\n"
-        "        type = \"OSC\"\n"
+        "        type = \"Any\"\n"
         "outputs\n"
         "    output\n"
-        "        type = \"OSC\"\n";
+        "        type = \"Any\"\n";
 
 
 void OSCRecord::handleEOF(sphactor_actor_t* actor) {

--- a/Actors/RecordActor.cpp
+++ b/Actors/RecordActor.cpp
@@ -156,22 +156,23 @@ Record::handleAPI(sphactor_event_t *ev )
     char * cmd = zmsg_popstr(ev->msg);
     if (cmd) {
         if ( streq(cmd, "START_RECORD") ) {
-            zsys_info("TODO: start recording if valid file & not recording");
-
-            // if ! recording
-
             // if file does not exist
-            // TODO: OR overwrite (for now, always overwrite)
             if ( file == nullptr ) {
                 if ( !zfile_exists(fileName) || overwrite ) {
                     file = zfile_new(NULL, fileName);
-                    zfile_output(file);
-                    write_offset = 0;
-                    zsys_info("file created");
+                    int rc = zfile_output(file);
+                    if (rc == 0) {
+                        write_offset = 0;
+                        zsys_info("file created");
 
-                    // Build report
-                    zosc_t * msg = zosc_create("/report", "ss", "Recording", "...");
-                    sphactor_actor_set_custom_report_data((sphactor_actor_t*)ev->actor, msg);
+                        // Build report
+                        zosc_t* msg = zosc_create("/report", "ss", "Recording", "...");
+                        sphactor_actor_set_custom_report_data((sphactor_actor_t*)ev->actor, msg);
+                    }
+                    else{
+                        file = nullptr;
+                        zsys_info("Invalid output file");
+                    }
                 }
                 else {
                     zsys_info("File exists. Check overwrite to replace before hitting record.");

--- a/Actors/RecordActor.h
+++ b/Actors/RecordActor.h
@@ -2,8 +2,8 @@
 // Created by Aaron Oostdijk on 28/10/2021.
 //
 
-#ifndef GAZEBOSC_OSCRECORDACTOR_H
-#define GAZEBOSC_OSCRECORDACTOR_H
+#ifndef GAZEBOSC_RECORDACTOR_H
+#define GAZEBOSC_RECORDACTOR_H
 
 #include "libsphactor.hpp"
 #include <string>
@@ -14,25 +14,28 @@ public:
     unsigned int bytes;
 };
 
-class OSCRecord : public Sphactor {
+class Record : public Sphactor {
 private:
 
 public:
     static const char *capabilities;
 
-    const char* fileName = nullptr;
+    // State variables
     zfile_t * file = nullptr;
-    int offset = 0;
     bool playing = false;
-    bool loop = false;
-    bool blockDuringPlay = false;
-
     unsigned int startTimeCode = 0;
     unsigned int startRecordTimeCode = 0;
     unsigned int read_offset = 0;
+    unsigned int write_offset = 0;
     time_bytes * current_tc = nullptr;
 
-    OSCRecord() : Sphactor() {
+    // Controls
+    const char* fileName = nullptr;
+    bool loop = false;
+    bool blockDuringPlay = false;
+    bool overwrite = false;
+
+    Record() : Sphactor() {
 
     }
 
@@ -46,4 +49,4 @@ public:
     // Or perhaps a fixed buffer, that writes when something is bigger than it can store?
 };
 
-#endif //GAZEBOSC_OSCRECORDACTOR_H
+#endif //GAZEBOSC_RECORDACTOR_H

--- a/ImNodes.cpp
+++ b/ImNodes.cpp
@@ -723,7 +723,7 @@ void EndSlot()
     {
         auto* payload = ImGui::GetDragDropPayload();
         char drag_id[32];
-        snprintf(drag_id, sizeof(drag_id), "new-node-connection-%08X", impl->slot.kind);
+        snprintf(drag_id, sizeof(drag_id), "new-node-connection-");//%08X", impl->slot.kind);
         if (payload == nullptr || !payload->IsDataType(drag_id))
         {
             _DragConnectionPayload drag_data{ };
@@ -748,7 +748,7 @@ void EndSlot()
     {
         // Accept drags from opposite type (input <-> output, and same kind)
         char drag_id[32];
-        snprintf(drag_id, sizeof(drag_id), "new-node-connection-%08X", impl->slot.kind * -1);
+        snprintf(drag_id, sizeof(drag_id), "new-node-connection-");//%08X", impl->slot.kind * -1);
 
         if (auto* payload = ImGui::AcceptDragDropPayload(drag_id))
         {
@@ -822,9 +822,10 @@ bool IsConnectingCompatibleSlot()
             return false;
 
         char drag_id[32];
-        snprintf(drag_id, sizeof(drag_id), "new-node-connection-%08X", impl->slot.kind * -1);
+        snprintf(drag_id, sizeof(drag_id), "new-node-connection-");//%08X", impl->slot.kind * -1);
+
         if (strcmp(drag_id, payload->DataType) != 0)
-            return false;
+           return false;
 
         for (int i = 0; i < impl->ignore_connections.size(); i++)
         {

--- a/ImNodes.h
+++ b/ImNodes.h
@@ -90,7 +90,7 @@ IMGUI_API void AutoPositionNode(void* node_id);
 /// called at id scope created by BeginNode().
 IMGUI_API bool GetNewConnection(void** input_node, const char** input_slot_title, void** output_node, const char** output_slot_title);
 /// Get information of connection that is being made and has only one end connected. Returns true when pending connection exists, false otherwise.
-IMGUI_API bool GetPendingConnection(void** node_id, const char** slot_title, int* slot_kind);
+IMGUI_API bool GetPendingConnection(void** node_id, const char** slot_title, int* slot_kind, bool* slot_any);
 /// Render a connection. Returns `true` when connection is present, `false` if it is deleted.
 IMGUI_API bool Connection(void* input_node, const char* input_slot, void* output_node, const char* output_slot);
 /// Returns active canvas state when called between BeginCanvas() and EndCanvas(). Returns nullptr otherwise. This function is not thread-safe.
@@ -104,11 +104,11 @@ inline bool IsInputSlotKind(int kind) { return kind < 0; }
 /// Returns `true` if `kind` is from output slot.
 inline bool IsOutputSlotKind(int kind) { return kind > 0; }
 /// Begins slot region. Kind is unique value indicating slot type. Negative values mean input slots, positive - output slots.
-IMGUI_API bool BeginSlot(const char* title, int kind);
+IMGUI_API bool BeginSlot(const char* title, int kind, bool any);
 /// Begins slot region. Kind is unique value whose sign is ignored.
-inline bool BeginInputSlot(const char* title, int kind) { return BeginSlot(title, InputSlotKind(kind)); }
+inline bool BeginInputSlot(const char* title, int kind, bool any) { return BeginSlot(title, InputSlotKind(kind), any); }
 /// Begins slot region. Kind is unique value whose sign is ignored.
-inline bool BeginOutputSlot(const char* title, int kind) { return BeginSlot(title, OutputSlotKind(kind)); }
+inline bool BeginOutputSlot(const char* title, int kind, bool any) { return BeginSlot(title, OutputSlotKind(kind), any); }
 /// Rends rendering of slot. Call only if Begin*Slot() returned `true`.
 IMGUI_API void EndSlot();
 /// Returns `true` if curve connected to current slot is hovered. Call between `Begin*Slot()` and `EndSlot()`. In-progress

--- a/ImNodesEz.cpp
+++ b/ImNodesEz.cpp
@@ -62,7 +62,7 @@ void EndNode()
     ImNodes::EndNode();
 }
 
-bool Slot(const char* title, int kind)
+bool Slot(const char* title, int kind, bool any)
 {
     auto* storage = ImGui::GetStateStorage();
     const auto& style = ImGui::GetStyle();
@@ -74,7 +74,7 @@ bool Slot(const char* title, int kind)
         item_offset_x = -item_offset_x;
     ImGui::SetCursorScreenPos(ImGui::GetCursorScreenPos() + ImVec2{item_offset_x, 0});
 
-    if (ImNodes::BeginSlot(title, kind))
+    if (ImNodes::BeginSlot(title, kind, any))
     {
         auto* draw_lists = ImGui::GetWindowDrawList();
 
@@ -145,7 +145,7 @@ void InputSlots(const SlotInfo* slots, int snum)
     ImGui::BeginGroup();
     {
         for (int i = 0; i < snum; i++)
-            ImNodes::Ez::Slot(slots[i].title, ImNodes::InputSlotKind(slots[i].kind));
+            ImNodes::Ez::Slot(slots[i].title, ImNodes::InputSlotKind(slots[i].kind), slots[i].any);
     }
     ImGui::EndGroup();
 
@@ -168,7 +168,7 @@ void OutputSlots(const SlotInfo* slots, int snum)
     ImGui::BeginGroup();
     {
         for (int i = 0; i < snum; i++)
-            ImNodes::Ez::Slot(slots[i].title, ImNodes::OutputSlotKind(slots[i].kind));
+            ImNodes::Ez::Slot(slots[i].title, ImNodes::OutputSlotKind(slots[i].kind), slots[i].any);
     }
     ImGui::EndGroup();
 }

--- a/ImNodesEz.h
+++ b/ImNodesEz.h
@@ -38,6 +38,7 @@ struct SlotInfo
     const char* title;
     /// Slot kind, will be used for matching connections to slots of same kind.
     int kind;
+    bool any;
 };
 
 /// Begin rendering of node in a graph. Render node content when returns `true`.

--- a/actors.h
+++ b/actors.h
@@ -7,7 +7,7 @@
 #include "Actors/NatNet2OSCActor.h"
 #include "Actors/OpenVRActor.h"
 #include "Actors/OSCInputActor.h"
-#include "Actors/OSCRecordActor.h"
+#include "Actors/RecordActor.h"
 #include "Actors/ModPlayerActor.h"
 #include "Actors/ProcessActor.h"
 #ifdef PYTHON3_FOUND

--- a/stage.cpp
+++ b/stage.cpp
@@ -115,7 +115,7 @@ void RegisterActors() {
     sphactor_register<OpenVR>("OpenVR", OpenVR::capabilities);
 #endif
     sphactor_register<OSCInput>( "OSC Input", OSCInput::capabilities );
-    sphactor_register<OSCRecord>( "OSC Record", OSCRecord::capabilities );
+    sphactor_register<Record>("Record", Record::capabilities );
     sphactor_register<ModPlayerActor>( "ModPlayer", ModPlayerActor::capabilities );
     sphactor_register<ProcessActor>( "Process", ProcessActor::capabilities );
 #ifdef PYTHON3_FOUND

--- a/stage.cpp
+++ b/stage.cpp
@@ -737,13 +737,12 @@ bool Load( const char* configFile ) {
             {
                 Connection new_connection;
                 new_connection.input_node = gActor;
-                new_connection.input_slot = "OSC";
+                new_connection.input_slot = gActor->input_slots[0].title;
                 new_connection.output_node = peer_actor_container;
-                new_connection.output_slot = "OSC";
+                new_connection.output_slot = peer_actor_container->output_slots[0].title;
                 ((ActorContainer*) new_connection.input_node)->connections.push_back(new_connection);
                 ((ActorContainer*) new_connection.output_node)->connections.push_back(new_connection);
             }
-
         }
         ++it;
     }


### PR DESCRIPTION
Fixed an issue with the NatNet actor when no interfaces exist.

More importantly: removed the restriction from ImNodes (slightly hacky, but I couldn't find any external way to do it) that types can only be connected to the same (or "opposite") types. Since the sphactor back-end doesn't care either way, this makes it more flexible. Upshot: record actor now uses "Any" slot type, and doesn't only accept OSC.

It also introduces the ability to create connections that would not work, so we'd need to think about supporting "error handling", or ignoring messages that are not usable by an actor.