### PR TITLE
fix crash when loading a nonexisting text file into the editor

### DIFF
--- a/ActorContainer.h
+++ b/ActorContainer.h
@@ -489,10 +489,10 @@ struct ActorContainer {
             {
                 zconfig_t* zvalue = zconfig_locate(data, "value");
                 const char* zvalueStr = zconfig_value(zvalue);
-                zfile_t* f = zfile_new(nullptr, zvalueStr);
-                if (strlen(zvalueStr) && f)
+                if (strlen(zvalueStr) && zsys_file_exists (zvalueStr) )
                 {
-                    OpenTextEditor(f);
+                    zfile_t* f = zfile_new(nullptr, zvalueStr);
+                    OpenTextEditor(f); // could own the f pointer
                 }
                 else
                     zsys_error("no valid file to load: %s", zvalueStr);

--- a/stage.cpp
+++ b/stage.cpp
@@ -309,6 +309,8 @@ void OpenTextEditor(zfile_t* txtfile)
     else {
         zsys_info("FOUND OPEN TEXT FILE!... maybe activate the correct tab?");
         hardswap_editor = found;
+        // cleanup not used txtfile
+        zfile_destroy(&txtfile);
     }
     txteditor_open = true;
 }


### PR DESCRIPTION
initial fix for #197