### PR TITLE
Updated natnet parsing for 3.1 compatibility

### DIFF
--- a/Actors/NatNet2OSCActor.cpp
+++ b/Actors/NatNet2OSCActor.cpp
@@ -456,44 +456,42 @@ char* NatNet2OSC::unpackRigidBodies(char* ptr, std::vector<RigidBody>& ref_rigid
 
         //TODO: These associated markers are no longer part of the 3.1 SDK example
        //          -> Check if we can/need to remove this...
+        if ( major < 3 ) {
+            // associated marker positions
+            int nRigidMarkers = 0;
+            memcpy(&nRigidMarkers, ptr, 4);
+            ptr += 4;
 
-        // associated marker positions
-        int nRigidMarkers = 0;
-        memcpy(&nRigidMarkers, ptr, 4);
-        ptr += 4;
-
-        int nBytes = nRigidMarkers * 3 * sizeof(float);
-        float* markerData = (float*)malloc(nBytes);
-        memcpy(markerData, ptr, nBytes);
-        ptr += nBytes;
-
-        if (major >= 2)
-        {
-            // associated marker IDs
-            nBytes = nRigidMarkers * sizeof(int);
+            int nBytes = nRigidMarkers * 3 * sizeof(float);
+            float *markerData = (float *) malloc(nBytes);
+            memcpy(markerData, ptr, nBytes);
             ptr += nBytes;
 
-            // associated marker sizes
-            nBytes = nRigidMarkers * sizeof(float);
-            ptr += nBytes;
+            if (major >= 2) {
+                // associated marker IDs
+                nBytes = nRigidMarkers * sizeof(int);
+                ptr += nBytes;
+
+                // associated marker sizes
+                nBytes = nRigidMarkers * sizeof(float);
+                ptr += nBytes;
+            }
+
+            RB.markers.resize(nRigidMarkers);
+
+            for (int k = 0; k < nRigidMarkers; k++) {
+                float x = markerData[k * 3];
+                float y = markerData[k * 3 + 1];
+                float z = markerData[k * 3 + 2];
+
+                glm::vec3 pp(x, y, z);
+                //TODO: Matrix, only used for scale previously
+                //pp = transform.preMult(pp);
+                RB.markers[k] = pp;
+            }
+
+            if (markerData) free(markerData);
         }
-
-        RB.markers.resize(nRigidMarkers);
-
-        for (int k = 0; k < nRigidMarkers; k++)
-        {
-            float x = markerData[k * 3];
-            float y = markerData[k * 3 + 1];
-            float z = markerData[k * 3 + 2];
-
-            glm::vec3 pp(x, y, z);
-            //TODO: Matrix, only used for scale previously
-            //pp = transform.preMult(pp);
-            RB.markers[k] = pp;
-        }
-
-        if (markerData) free(markerData);
-
         // TODO: 3.1 SDK Contains everything after this again
 
         if (major >= 2)

--- a/Actors/NatNet2OSCActor.cpp
+++ b/Actors/NatNet2OSCActor.cpp
@@ -979,6 +979,8 @@ void NatNet2OSC::Unpack( char ** pData ) {
                     //description.joints[i].offset[0] = xoffset;
                     //description.joints[i].offset[0] = yoffset;
                     //description.joints[i].offset[0] = zoffset;
+
+                    while ( *ptr == '\0' ) ptr++;
                 }
                 //tmp_skeleton_descs.push_back(description);
             }

--- a/Actors/NatNetActor.cpp
+++ b/Actors/NatNetActor.cpp
@@ -1001,7 +1001,7 @@ void NatNet::Unpack( char ** pData ) {
                     description.joints[i].offset[0] = xoffset;
                     description.joints[i].offset[1] = yoffset;
                     description.joints[i].offset[2] = zoffset;
-                    
+
                     while ( *ptr == '\0' ) ptr ++;
                 }
                 tmp_skeleton_descs.push_back(description);

--- a/Actors/NatNetActor.h
+++ b/Actors/NatNetActor.h
@@ -65,6 +65,7 @@ public:
     //NatNet parse functions
     int SendCommand(char* szCOmmand);
     void HandleCommand(sPacket *PacketIn);
+    void SendPing();
 
     void Unpack( char ** pData );
     char* unpackRigidBodies(char* ptr, std::vector<RigidBody>& ref_rigidbodies);


### PR DESCRIPTION
Put an if-statement around previously suspected issue TODO, and preventing parsing packets when we don't have version information. Might need to update the reset button to also re-send PING packets.

Don't merge until further commits are made/tested.