### PR TITLE
NatNet 3.1 packing workaround

### DIFF
--- a/Actors/NatNet2OSCActor.cpp
+++ b/Actors/NatNet2OSCActor.cpp
@@ -980,7 +980,10 @@ void NatNet2OSC::Unpack( char ** pData ) {
                     //description.joints[i].offset[0] = yoffset;
                     //description.joints[i].offset[0] = zoffset;
 
-                    while ( *ptr == '\0' ) ptr++;
+                    // TODO: Figure out how to recognize if this is extra padding, or a type 0 markerset
+                    if ( major >= 3 ) {
+                        while (*ptr == '\0') ptr++;
+                    }
                 }
                 //tmp_skeleton_descs.push_back(description);
             }

--- a/Actors/NatNetActor.cpp
+++ b/Actors/NatNetActor.cpp
@@ -1002,7 +1002,10 @@ void NatNet::Unpack( char ** pData ) {
                     description.joints[i].offset[1] = yoffset;
                     description.joints[i].offset[2] = zoffset;
 
-                    while ( *ptr == '\0' ) ptr ++;
+                    // TODO: Figure out how to recognize if this is extra padding, or a type 0 markerset
+                    if ( major >= 3 ) {
+                        while (*ptr == '\0') ptr++;
+                    }
                 }
                 tmp_skeleton_descs.push_back(description);
             }


### PR DESCRIPTION
Don't merge yet until we can verify the solution is robust.

To at least make it work with the previous versions, I've added a "major >= 3" check to the padding workaround when receiving SkeletonDefinitions from Motive 2.3.1

The problem is, that workaround skips "0" values, which are also valid "Type = 0" markerset descriptions. If you receive them the order: skeleton -> markerset, the parse breaks.

We'll have to figure out how to recognise the padding issue, or resolve it some other way.