### PR TITLE
Fixes to record actor & related code

### DIFF
--- a/ActorContainer.h
+++ b/ActorContainer.h
@@ -21,6 +21,13 @@ convert_to_relative_to_wd(const char *path)
 {
     char wdpath[PATH_MAX];
     getcwd(wdpath, PATH_MAX);
+
+#if WIN32
+    std::string pathStr = wdpath;
+    std::replace(pathStr.begin(), pathStr.end(), '\\', '/');
+    strcpy(wdpath, pathStr.c_str());
+#endif
+
     const char *ret = strstr(path, wdpath);
     if (ret == NULL)
         return strdup(path);

--- a/Actors/RecordActor.cpp
+++ b/Actors/RecordActor.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "RecordActor.h"
+#include <algorithm>
 
 const char * Record::capabilities =
         "capabilities\n"
@@ -160,8 +161,13 @@ Record::handleAPI(sphactor_event_t *ev )
             // if file does not exist
             if ( file == nullptr ) {
                 if ( !zfile_exists(fileName) || overwrite ) {
+                    if (zfile_exists(fileName)) {
+                        // delete the contents of the file
+                        zfile_delete(fileName);
+                    }
+
                     //TODO: Check if fileName is relative path or not
-                    if ( fileName[0] == '/') {
+                    if (isAbsolutePath(fileName)) {
                         file = zfile_new(NULL, fileName);
                     }
                     else {
@@ -206,7 +212,7 @@ Record::handleAPI(sphactor_event_t *ev )
         else if ( streq(cmd, "PLAY_RECORDING") ) {
             if ( file == nullptr && !playing ) {
                 if ( zfile_exists(fileName) ) {
-                    if ( fileName[0] == '/') {
+                    if (isAbsolutePath(fileName)) {
                         file = zfile_new(NULL, fileName);
                     }
                     else {

--- a/Actors/RecordActor.h
+++ b/Actors/RecordActor.h
@@ -39,6 +39,14 @@ public:
 
     }
 
+    bool isAbsolutePath(const char* path) {
+#if WIN32
+        return (path[1] == ':' && ( path[2] == '\\' || path[2] == '/' ));
+#else
+        return path[0] == '/';
+#endif
+    }
+
     void handleEOF( sphactor_actor_t * actor );
     void setReport( sphactor_actor_t * actor );
 

--- a/build_windows.bat
+++ b/build_windows.bat
@@ -19,5 +19,6 @@ cmake .. -DCMAKE_PREFIX_PATH="%cd%/tmp/ci_build" -DCMAKE_INSTALL_PREFIX="%INSTAL
 cmake --build . --config Debug --target install
 
 copy "%LIBZMQ_BUILDDIR%\bin\Debug\*.dll" "%GZB_BUILDDIR%\bin\Debug\*.dll"
+copy "%PROJECT_ROOT%\tmp\ci_build\*.dll" "%GZB_BUILDDIR%\bin\Debug\*.dll"
 
 cd %PROJECT_ROOT%


### PR DESCRIPTION
The conversion to local file names now works correctly on windows (at least for me). Currently uses std::replace, which might not be the most efficient.

Record actor now also deletes existing file when you overwrite the recording. I'm thinking the overwrite flag should turn off each time a recording has been made, so you must manually indicate you want to do it again. Just need to figure out how to propagate that to the UI.