### PR TITLE
Usability Fixes

### DIFF
--- a/ActorContainer.h
+++ b/ActorContainer.h
@@ -200,6 +200,11 @@ struct ActorContainer {
         }
     }
 
+    void SetCapabilities(const char* capabilities ) {
+        this->capabilities = zconfig_str_load(capabilities);
+        InitializeCapabilities();
+    }
+
     char *itoa(int i)
     {
         char *str = (char *)malloc(10);
@@ -267,7 +272,7 @@ struct ActorContainer {
                     } break;
                 }
             }
-            else {
+            else if (zvalue) {
                 //assume string
                 //int ival;
                 //ReadInt(&ival, zvalue);
@@ -722,7 +727,7 @@ struct ActorContainer {
 
         ImGui::SetNextItemWidth(100);
 
-        if ( ImGui::InputInt( name, &value, step, 100,ImGuiInputTextFlags_EnterReturnsTrue ) ) {
+        if ( ImGui::InputInt( name, &value, step, 100) ) {
             if ( zmin ) {
                 if (value < min) value = min;
             }
@@ -878,11 +883,11 @@ struct ActorContainer {
         char *p = &buf[0];
 
         ImGui::SetNextItemWidth(200);
-        if ( ImGui::InputText(name, buf, max, ImGuiInputTextFlags_EnterReturnsTrue ) ) {
+        if ( ImGui::InputText(name, buf, max) ) {
             zconfig_set_value(zvalue, "%s", buf);
-            //SendAPI<char*>(zapic, zapiv, zvalue, &(p));
-            sphactor_ask_api(this->actor, zconfig_value(zapic), zconfig_value(zapiv), buf );
+            sphactor_ask_api(this->actor, zconfig_value(zapic), zconfig_value(zapiv), buf);
         }
+
         zconfig_t *help = zconfig_locate(data, "help");
         if (help)
         {

--- a/Actors/DmxActor.cpp
+++ b/Actors/DmxActor.cpp
@@ -189,6 +189,8 @@ s_get_serialports()
 
     zlist_destroy(&dirlist);
     zdir_destroy(&serdir);
+
+    return names;
 #elif defined __WINDOWS__
     zlist_t *dirlist = list_winserialports();
     char *item = (char *)zlist_first(dirlist);

--- a/Actors/NatNetActor.cpp
+++ b/Actors/NatNetActor.cpp
@@ -33,6 +33,7 @@ const char * NatNet::capabilities =
                                 "        value = \"60\"\n"
                                 "        api_call = \"SET TIMEOUT\"\n"
                                 "        api_value = \"i\"\n"           // optional picture format used in zsock_send
+                                "        min = 1\n"
                                 "    data\n"
                                 "        name = \"Reset\"\n"
                                 "        type = \"trigger\"\n"

--- a/main.cpp
+++ b/main.cpp
@@ -479,6 +479,7 @@ ImGuiIO& ImGUIInit(SDL_Window* window, SDL_GLContext* gl_context, const char* gl
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();
     ImGuiIO& io = ImGui::GetIO(); (void)io;
+    io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
 
     // Setup Dear ImGui style
     ImGui::StyleColorsDark();

--- a/stage.cpp
+++ b/stage.cpp
@@ -683,13 +683,66 @@ inline ImU32 LerpImU32( ImU32 c1, ImU32 c2, int index, int total, float offset, 
 
 int UpdateActors(float deltaTime, bool * showLog)
 {
+    static ActorContainer * selectedActor = nullptr;
+    static char * actorClipboardType = nullptr;
+    static char * actorClipboardCapabilities = nullptr;
+
     int rc = 0;
     static ImNodes::Ez::Context* context = ImNodes::Ez::CreateContext();
     IM_UNUSED(context);
 
-    //const ImGuiStyle& style = ImGui::GetStyle();
-
     ImGui::SetNextWindowPos(ImVec2(0,0));
+
+    ImGuiIO &io = ImGui::GetIO();
+    bool copy = ImGui::IsKeyPressedMap(ImGuiKey_C) && (io.KeySuper || io.KeyCtrl);
+    bool paste = ImGui::IsKeyPressedMap(ImGuiKey_V) && (io.KeySuper || io.KeyCtrl);
+    bool del = ImGui::IsKeyPressedMap(ImGuiKey_Delete) || (io.KeySuper && ImGui::IsKeyPressedMap(ImGuiKey_Backspace));
+
+    if ( selectedActor != nullptr && copy )
+    {
+        // copy actor data to clipboard char *'s
+        zsys_info("COPY" );
+
+        if ( actorClipboardType != nullptr ) {
+            free(actorClipboardType);
+            free(actorClipboardCapabilities);
+            actorClipboardType = nullptr;
+            actorClipboardCapabilities = nullptr;
+        }
+
+        actorClipboardCapabilities = zconfig_str_save(selectedActor->capabilities);
+
+        int length = strlen(selectedActor->title);
+        actorClipboardType = new char[length+1];
+        strncpy(actorClipboardType, selectedActor->title, length);
+        actorClipboardType[length] = '\0';
+    }
+    if ( actorClipboardType != nullptr ){
+        if (paste) {
+            // create actor from clipboard
+            // clear clipboard
+            zsys_info("PASTE: %s", actorClipboardType);
+
+            int max = -1;
+            if ( max_actors_by_type.find(actorClipboardType) != max_actors_by_type.end() )
+                max = max_actors_by_type.at(actorClipboardType);
+
+            if ( CountActorsOfType(actorClipboardType) < max || max == -1) {
+                ActorContainer *actor = CreateFromType(actorClipboardType, nullptr);
+                actor->SetCapabilities(actorClipboardCapabilities);
+                actor->pos = io.MousePos;
+                actors.push_back(actor);
+            }
+
+            // TODO: figure out when we need to clear this (if ever)
+            /*
+            free(actorClipboardType);
+            free(actorClipboardCapabilities);
+            actorClipboardType = nullptr;
+            actorClipboardCapabilities = nullptr;
+             */
+        }
+    }
 
     if (ImGui::Begin("ImNodes", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_MenuBar ))
     {
@@ -789,25 +842,29 @@ int UpdateActors(float deltaTime, bool * showLog)
             // Node rendering is done. This call will render node background based on size of content inside node.
             ImNodes::Ez::EndNode();
 
-            bool del = ImGui::IsKeyPressedMap(ImGuiKey_Delete) || ( ImGui::IsKeyPressedMap(ImGuiKey_Backspace) && ImGui::GetActiveID() == 0 );
-            if (actor->selected && del && ImGui::IsWindowFocused() )
-            {
-                // Loop and delete connections of actors connected to us
-                for (auto& connection : actor->connections)
-                {
-                    if (connection.output_node == actor) {
-                        ((ActorContainer*) connection.input_node)->DeleteConnection(connection);
-                    }
-                    else {
-                        ((ActorContainer*) connection.output_node)->DeleteConnection(connection);
-                    }
-                }
-                // Delete all our connections separately
-                actor->connections.clear();
-                sph_stage_remove_actor(stage, zuuid_str(sphactor_ask_uuid(actor->actor)));
+            if ( actor->selected) {
+                if (del) {
+                    zsys_info("DEL?");
 
-                delete actor;
-                it = actors.erase(it);
+                    // Loop and delete connections of actors connected to us
+                    for (auto &connection : actor->connections) {
+                        if (connection.output_node == actor) {
+                            ((ActorContainer *) connection.input_node)->DeleteConnection(connection);
+                        } else {
+                            ((ActorContainer *) connection.output_node)->DeleteConnection(connection);
+                        }
+                    }
+                    // Delete all our connections separately
+                    selectedActor->connections.clear();
+                    sph_stage_remove_actor(stage, zuuid_str(sphactor_ask_uuid(actor->actor)));
+
+                    delete actor;
+                    actors.erase(it);
+                }
+                else {
+                    selectedActor = actor;
+                    ++it;
+                }
             }
             else
                 ++it;
@@ -817,6 +874,9 @@ int UpdateActors(float deltaTime, bool * showLog)
         {
             ImGui::FocusWindow(ImGui::GetCurrentWindow());
             ImGui::OpenPopup("NodesContextMenu");
+        }
+        else if ( ImGui::IsMouseReleased(0) && !ImGui::IsAnyItemHovered() && !ImGui::IsMouseDragging(0)) {
+            selectedActor = nullptr;
         }
 
         if (ImGui::BeginPopup("NodesContextMenu"))


### PR DESCRIPTION
Implemented **multi-select copy/paste**. This basically takes the title, zconfig capabilities string & relative position of any selected actor, and uses CreateFromType and a new function "SetCapabilities" to re-create & inject the copied actor. Also respects max actor count (on paste)

Removed the enter restriction from input fields. Actors should be able to deal with nonsensical input (since they do this even when we hit enter). There is an ImGui issue that's been open for years that seeks to address this, maybe we can help it along to make this better: https://github.com/ocornut/imgui/issues/701 

**Issue**: we're hitting socket limits if we copy/paste a lot of nodes, so we should probably handle this "exceeded max actors" more gracefully. Or just increase the socket limit through the environment to some ridiculous amount (or at this point).

Also includes some fixes:
- DmxActor wasn't returning the list of port names on OSX
- NatNetActor would hang if timeout was set to 0 (so minimum 1 was added)