### PR TITLE
Implemented lock_guard for looping & writing descriptions

### DIFF
--- a/Actors/NatNetActor.cpp
+++ b/Actors/NatNetActor.cpp
@@ -9,6 +9,7 @@ int* NatNet::ServerVersion = new int[4]{0,0,0,0};
 std::vector<RigidBodyDescription> NatNet::rigidbody_descs;
 std::vector<SkeletonDescription> NatNet::skeleton_descs;
 std::vector<MarkerSetDescription> NatNet::markerset_descs;
+std::mutex NatNet::desc_mutex;
 
 const char * NatNet::capabilities =
                                 "capabilities\n"
@@ -1155,9 +1156,13 @@ void NatNet::Unpack( char ** pData ) {
         //zsys_info("End Packet\n-------------\n");
 
         //Store data
-        this->markerset_descs = tmp_markerset_descs;
-        this->rigidbody_descs = tmp_rigidbody_descs;
-        this->skeleton_descs = tmp_skeleton_descs;
+        // Lock while doing this (loops to read them must finish and can't start @ NatNet2OSCActor)
+        {
+            const std::lock_guard<std::mutex> lock(desc_mutex);
+            this->markerset_descs = tmp_markerset_descs;
+            this->rigidbody_descs = tmp_rigidbody_descs;
+            this->skeleton_descs = tmp_skeleton_descs;
+        }
     }
     else
     {

--- a/Actors/NatNetActor.h
+++ b/Actors/NatNetActor.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <map>
 #include "NatNetDataTypes.h"
+#include <mutex>
 
 class NatNet : public Sphactor {
 public:
@@ -54,6 +55,8 @@ public:
     static std::vector<RigidBodyDescription> rigidbody_descs;
     static std::vector<SkeletonDescription> skeleton_descs;
     static std::vector<MarkerSetDescription> markerset_descs;
+
+    static std::mutex desc_mutex;
 
     zmsg_t* handleInit(sphactor_event_t *ev);
     zmsg_t* handleTimer(sphactor_event_t *ev);


### PR DESCRIPTION
Seems relatively straight forward, since we use temporary vectors that get set to the static description vectors in one place. The lock should only need to be around this, and where the osc message gets built (since that's the only loop that depends on their size and contents).

Needs testing. Should fix #253 