### PR TITLE
fix sign error when compiling with python 3.13

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -47,7 +47,7 @@ jobs:
         repo-name: obs
         repo: deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_22.04/ ./
         keys-asc: https://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_22.04/Release.key
-        install: libzmq5 libzmq3-dev libglx-dev mesa-common-dev libasound2-dev libglew-dev libunwind-dev libmicrohttpd-dev
+        install: libzmq5 libzmq3-dev libglx-dev mesa-common-dev libasound2-dev libglew-dev libunwind-dev libmicrohttpd-dev libxext-dev
 
     - name: Add brew packages
       if: ${{ contains( matrix.os, 'macos' ) }}

--- a/actors/pyzmsg.h
+++ b/actors/pyzmsg.h
@@ -130,7 +130,7 @@ static PyMethodDef PyZmsg_methods[] = {
 };*/
 
 static PyTypeObject PyZmsgType = {
-    PyObject_HEAD_INIT(NULL)
+    PyVarObject_HEAD_INIT(NULL, 0)
     "internal.Zmsg",           // tp_name
     sizeof(PyZmsgObject),      // tp_basicsize
     0,                         // tp_itemsize


### PR DESCRIPTION
use newer PyVarObjec_HEAD_INIT macro instead of PyObject_HEAD_INIT